### PR TITLE
Add Multiplayer Boss Titan Support

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -78,6 +78,13 @@
                 "After": "Nessie_ChatCommands_Utility_Init"
             }
 		},
+		{
+			"Path": "/nessieutil/npc_freeze.gnut",
+			"RunOn": "SERVER",
+			"ServerCallback": {
+                "After": "Nessie_NPC_Freeze_Init"
+            }
+		},
 		// nessie utility end
 		// modifiers
 		{
@@ -731,6 +738,29 @@
             }
 		},
 		// modded softball end
+		// multiplayer boss titan
+		{
+			"Path": "/modai/_boss_titan_mp.gnut",
+			"RunOn": "SERVER",
+			"ServerCallback": {
+                "After": "Multiplayer_BossTitan_Init"
+            }
+		},
+		{
+			"Path": "/modai/_boss_titan_intro.gnut",
+			"RunOn": "SERVER",
+			"ServerCallback": {
+                "After": "MP_Boss_Titans_Intro_Init"
+            }
+		},
+		{
+			"Path": "/modai/_boss_titan_conversation.gnut",
+			"RunOn": "SERVER",
+			"ServerCallback": {
+                "After": "MP_BossTitan_Conversation_Init"
+            }
+		},
+		// multiplayer boss titan end
 		{
 			"Path": "/modai/_ai_shield_drone.gnut",
 			"RunOn": "SERVER",

--- a/mod/scripts/vscripts/_misc_stubs.gnut
+++ b/mod/scripts/vscripts/_misc_stubs.gnut
@@ -1,0 +1,25 @@
+// todo figure out where these stub functions should be and move them to those places
+global function FW_Border_GlobalInit
+//global function IsVDUTitan // added by _boss_titan_mp.gnut
+
+void function FW_Border_GlobalInit()
+{
+	AddSpawnCallbackEditorClass( "func_brush", "func_brush_fw_territory_border", RemoveFWBorder )
+}
+
+void function RemoveFWBorder( entity border )
+{
+	if ( GameModeRemove( border ) )
+		return
+
+	if ( !border.HasKey( "gamemode_" + GAMETYPE ) )
+		border.Destroy()
+}
+
+// added by _boss_titan_mp.gnut
+/*
+bool function IsVDUTitan( entity titan )
+{
+	return false
+}
+*/

--- a/mod/scripts/vscripts/conversation/_conversation_schedule.gnut
+++ b/mod/scripts/vscripts/conversation/_conversation_schedule.gnut
@@ -28,10 +28,15 @@ global function CodeCallback_OnNPCLookAtHint
 
 global function ScriptDialog_PilotCloaked
 
+// respawn hardcoded things, needs to be callbacks
+global function AddCallback_CodeDialogue
+
 struct
 {
 	array< void functionref( entity ) > codeDialogueFunc
 
+	// respawn hardcoded things, needs to be callbacks
+	table< int, array<void functionref( entity )> > codeDialogueCallbacks
 } file
 
 void function DialogueScheduleServer_Init()
@@ -606,6 +611,9 @@ void function CodeCallback_ScriptedDialogue( entity guy, int dialogueID )
 	if ( dialogueID in file.codeDialogueFunc )
 	{
 		file.codeDialogueFunc[ dialogueID ]( guy )
+
+		// respawn hardcoded things, needs to be callbacks
+		RunCallbacksForCodeDialogue( dialogueID, guy )
 	}
 }
 
@@ -626,4 +634,23 @@ int function GetConversationIndex( string conversation )
 
 void function CodeCallback_OnNPCLookAtHint( entity npc, entity hint )
 {
+}
+
+
+// respawn hardcoded things, needs to be callbacks
+void function AddCallback_CodeDialogue( int dialogueID, void functionref( entity ) callbackFunc )
+{
+	if ( !( dialogueID in file.codeDialogueCallbacks ) )
+		file.codeDialogueCallbacks[ dialogueID ] <- []
+	if ( !file.codeDialogueCallbacks[ dialogueID ].contains( callbackFunc ) )
+		file.codeDialogueCallbacks[ dialogueID ].append( callbackFunc )
+}
+
+void function RunCallbacksForCodeDialogue( int dialogueID, entity guy )
+{
+	if ( !( dialogueID in file.codeDialogueCallbacks ) ) // not initialized dialogue id means no callbacks added
+		return
+
+	foreach ( void functionref( entity ) callbackFunc in file.codeDialogueCallbacks[ dialogueID ] )
+		callbackFunc( guy )
 }

--- a/mod/scripts/vscripts/modai/_boss_titan_conversation.gnut
+++ b/mod/scripts/vscripts/modai/_boss_titan_conversation.gnut
@@ -1,0 +1,1403 @@
+// From campaign, make it a server-side version
+untyped
+global function MP_BossTitan_Conversation_Init
+
+global function MpBossTitan_SetTitanConversationStyle
+global function MpBossTitan_PlayConversationDefault // based on titan's conversation style
+global function MpBossTitan_PlayConversationToTarget // play conversation to current target(eBossTitanConvStyle.PLAY_TO_TARGET)
+global function MpBossTitan_PlayConversationToAll // play conversation to all players(eBossTitanConvStyle.PLAY_TO_ALL)
+// main utility
+global function MpBossTitan_TryPlayConversationToPlayer
+
+// random conversation
+global function MpBossTitan_StartTitanRandomLines
+global function MpBossTitan_StopTitanRandomLines
+
+// intro conversations
+global function MpBossTitan_ConversationPostIntro
+global function MpBossTitan_ConversationNoIntro
+
+// player damage boss conversations
+global function MpBossTitan_ConversationDamaged
+global function MpBossTitan_ConversationLostSegment
+global function MpBossTitan_ConversationDoomed
+global function MpBossTitan_ConversationDeath
+// boss ability react conversations
+global function MpBossTitan_SetTitanEnableCoreConversation
+global function MpBossTitan_ConversationUseCoreAbility
+global function MpBossTitan_ConversationRetreat
+global function MpBossTitan_ConversationAdvance
+
+// boss damage player conversations
+global function MpBossTitan_ConversationTookPlayerSegment
+// boss react player ability conversations
+global function MpBossTitan_ConversationPlayerUseCoreAbility
+
+const float BOSS_TITAN_LINE_TIMEOUT = 10.0
+
+// debug
+const bool BOSS_TITAN_LINE_DEBUG_PRINT = false
+
+global enum eBossTitanConvStyle
+{
+    PLAY_TO_TARGET, // default
+    PLAY_TO_ALL,
+    DISABLED
+}
+
+struct MpBossTitanLine
+{
+	int conversationStyle = eBossTitanConvStyle.PLAY_TO_TARGET
+	string lastPlayedSoundAlias = ""
+	bool enableCoreConversation = true
+}
+
+struct MpBossTitanLineReceiver // player struct
+{
+	string lastPlayedSoundAlias = ""
+	entity lastSpeakerTitan = null
+}
+
+
+// from sh_ai_boss_titan.gnut
+// use array<string> is enough for mp
+/*
+struct BossTitanConversation
+{
+	array<string> soundAliases
+	// shouldn't include for mp
+	//array<string> usedAliases
+	//int eventPriority
+	//string eventVisualStyle
+	//asset customVideo
+}
+*/
+
+struct
+{
+    table<entity, MpBossTitanLine> mpBossTitanConversation
+	table<entity, MpBossTitanLineReceiver> mpBossTitanLineReceiver // player struct
+
+    // from sh_ai_boss_titan.gnut, adding support per player
+    table< string, table< string, array<string> > > bossTitanConvData // use array<string> is enough
+	table< entity, table<string, float> > aliasUsedTimesOnPlayer
+
+    // from cl_ai_boss_titan.gnut, adding support per player or per boss
+    table<entity, float> bossNextRandomLineTime
+	table< entity, float > lastSaidLineTimeOnPlayer // handling last said line
+    table< entity, table<string, float> > lastSaidLineTimesOnPlayer // handling multiple lines
+
+	// from struct, needs to move out to specific for player
+	table< entity, array<string> > usedAliasesOnPlayer
+} file
+
+void function MP_BossTitan_Conversation_Init()
+{
+	#if !BOSS_TITAN_LINE_DEBUG_PRINT // debug should always init
+		if ( IsLobby() )
+			return
+	#endif
+
+	// initialize data(needs modded rpak)
+	InitBossTitanConversationData()
+
+	// signals from sh_ai_boss_titan
+	RegisterSignal( "CancelBossConversation" )
+
+	RegisterSignal( "StopBossTitanRandomLines" )
+
+    AddCallback_OnClientConnected( OnClientConnected )
+
+	AddCallback_OnMpBossTitanRegister( OnBossTitanRegister )
+	AddCallback_OnMpBosstitanDeregister( OnBossTitanDeregister )
+}
+
+
+
+//  ___ _   _ ___ _____ ___    _    _     ___ __________     ____    _  _____  _    
+// |_ _| \ | |_ _|_   _|_ _|  / \  | |   |_ _|__  / ____|   |  _ \  / \|_   _|/ \   
+//  | ||  \| || |  | |  | |  / _ \ | |    | |  / /|  _|     | | | |/ _ \ | | / _ \  
+//  | || |\  || |  | |  | | / ___ \| |___ | | / /_| |___    | |_| / ___ \| |/ ___ \ 
+// |___|_| \_|___| |_| |___/_/   \_\_____|___/____|_____|   |____/_/   \_\_/_/   \_\
+
+// initialize data(needs modded rpak)
+void function InitBossTitanConversationData()
+{
+	// fill boss fields
+    // I can't handle datatable importing, let's just fill it by hand
+    /*
+	var dataTable = GetDataTable( $"datatable/titan_boss_lines.rpak" )
+	for ( int i = 0; i < GetDatatableRowCount( dataTable ); i++ )
+	{
+		string bossName	= GetDataTableString( dataTable, i, GetDataTableColumnByName( dataTable, "characterName" ) )
+		string eventName = GetDataTableString( dataTable, i, GetDataTableColumnByName( dataTable, "event" ) )
+
+		if (!( bossName in file.bossTitanConvData ) )
+			file.bossTitanConvData[ bossName ] <- {}
+
+		if (!( eventName in file.bossTitanConvData[ bossName ] ))
+		{
+			BossTitanConversation data
+			// shouldn't include for mp
+			// data.eventPriority = GetDataTableInt( dataTable, i, GetDataTableColumnByName( dataTable, "priority" ) )
+			// data.eventVisualStyle = GetDataTableString( dataTable, i, GetDataTableColumnByName( dataTable, "visualStyle" ) )
+			// if ( data.eventVisualStyle == "vdu_custom" )
+			// {
+			// 	data.customVideo = GetDataTableAsset( dataTable, i, GetDataTableColumnByName( dataTable, "customVideo" ) )
+			// 	PrecacheMaterial( data.customVideo )
+			// }
+
+			file.bossTitanConvData[ bossName ][ eventName ] <- data
+		}
+
+		string soundAlias = GetDataTableString( dataTable, i, GetDataTableColumnByName( dataTable, "audio" ) )
+		file.bossTitanConvData[ bossName ][ eventName ].soundAliases.append( soundAlias )
+	}
+	*/
+
+	// only one issue left: init data will make all dialogues belong to a single struct
+
+	// remove struct. using array<string> is enough for mp
+	//table<string, BossTitanConversation> emptyTable
+	//BossTitanConversation emptyData
+	//BossTitanConversation currentData
+	table< string, array<string> > emptyTable
+	array<string> emptyData
+	array<string> currentData
+
+	///////////
+	/// Ash ///
+	///////////
+	file.bossTitanConvData[ "Ash" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_doomed" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_playerUsedCoreAbility" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_coreAbility" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_random" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_playerUsedCoreAbility_boss1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_tookPlayerSegment_boss1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_coreAbility_boss1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_random_boss1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_coreAbility_backup" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_retreat" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_advance" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_tookPlayerSegment_backup" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_playerUsedCoreAbility_backup" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_random_backup" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_post_intro" ]
+	#if BOSS_TITAN_LINE_DEBUG_PRINT
+		print( "currentData print: " + string( currentData ) )
+	#endif
+	currentData.append( "diag_sp_BossVdu_BM112_02_01_imc_ash" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_2segmentsLeft" ]
+	#if BOSS_TITAN_LINE_DEBUG_PRINT
+		print( "currentData print: " + string( currentData ) )
+	#endif
+	currentData.append( "diag_sp_BossVdu_BM112_03_01_imc_ash" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_1segmentLeft" ]
+	currentData.append( "diag_sp_BossVdu_BM112_04_01_imc_ash" )
+	// doomed
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_doomed" ]
+	currentData.append( "diag_sp_BossVdu_BM112_05_01_imc_ash" )
+	// death
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_death" ]
+	currentData.append( "diag_sp_BossVdu_BM111_06_01_imc_ash" )
+	// playerUsedCoreAbility
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_playerUsedCoreAbility" ]
+	currentData.append( "diag_sp_BossVdu_BM112_07_01_imc_ash" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.append( "diag_sp_BossVdu_BM112_08_01_imc_ash" )
+	// coreAbility
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_coreAbility" ]
+	currentData.append( "diag_sp_BossVdu_BM112_09_01_imc_ash" )
+	// random
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_random" ]
+	currentData.append( "diag_sp_BossVdu_BM112_10_01_imc_ash" )
+	currentData.append( "diag_sp_BossVdu_BM112_11_01_imc_ash" )
+	currentData.append( "diag_sp_BossVdu_BM112_12_01_imc_ash" )
+	// playerUsedCoreAbility_boss1segmentLeft
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_playerUsedCoreAbility_boss1segmentLeft" ]
+	currentData.append( "diag_sp_BossVdu_BM112_13_01_imc_ash" )
+	// tookPlayerSegment_boss1segmentLeft
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_tookPlayerSegment_boss1segmentLeft" ]
+	currentData.append( "diag_sp_BossVdu_BM112_14_01_imc_ash" )
+	// coreAbility_boss1segmentLeft
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_coreAbility_boss1segmentLeft" ]
+	currentData.append( "diag_sp_BossVdu_BM112_15_01_imc_ash" )
+	// random_boss1segmentLeft
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_random_boss1segmentLeft" ]
+	currentData.append( "diag_sp_BossVdu_BM112_16_01_imc_ash" )
+	// coreAbility_backup
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_coreAbility_backup" ]
+	currentData.append( "diag_sp_BossVdu_BM112_17_01_imc_ash" )
+	currentData.append( "diag_sp_BossVdu_BM112_18_01_imc_ash" )
+	// retreat
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_retreat" ]
+	currentData.append( "diag_sp_BossVdu_BM112_19_01_imc_ash" )
+	currentData.append( "diag_sp_BossVdu_BM112_20_01_imc_ash" )
+	currentData.append( "diag_sp_BossVdu_BM112_21_01_imc_ash" )
+	currentData.append( "diag_sp_BossVdu_BM112_22_01_imc_ash" )
+	// advance
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_advance" ]
+	currentData.append( "diag_sp_BossVdu_BM112_23_01_imc_ash" )
+	currentData.append( "diag_sp_BossVdu_BM112_24_01_imc_ash" )
+	currentData.append( "diag_sp_BossVdu_BM112_25_01_imc_ash" )
+	currentData.append( "diag_sp_BossVdu_BM112_26_01_imc_ash" )
+	// tookPlayerSegment_backup
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_tookPlayerSegment_backup" ]
+	currentData.append( "diag_sp_BossVdu_BM112_27_01_imc_ash" )
+	currentData.append( "diag_sp_BossVdu_BM112_28_01_imc_ash" )
+	currentData.append( "diag_sp_BossVdu_BM112_29_01_imc_ash" )
+	// playerUsedCoreAbility_backup
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_playerUsedCoreAbility_backup" ]
+	currentData.append( "diag_sp_BossVdu_BM112_30_01_imc_ash" )
+	currentData.append( "diag_sp_BossVdu_BM112_31_01_imc_ash" )
+	currentData.append( "diag_sp_BossVdu_BM112_32_01_imc_ash" )
+	// random_backup
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_random_backup" ]
+	currentData.append( "diag_sp_BossVdu_BM112_33_01_imc_ash" )
+	currentData.append( "diag_sp_BossVdu_BM112_34_01_imc_ash" )
+	currentData.append( "diag_sp_BossVdu_BM112_35_01_imc_ash" )
+	currentData.append( "diag_sp_BossVdu_BM112_36_01_imc_ash" )
+
+	/////////////
+	/// Viper ///
+	/////////////
+	file.bossTitanConvData[ "Viper" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_doomed" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_playerUsedCoreAbility" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_coreAbility" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_random" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_playerUsedCoreAbility_boss1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_tookPlayerSegment_boss1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_coreAbility_boss1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_random_boss1segmentLeft" ] <- clone emptyData
+	// viper don't have coreAbility_backup
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_retreat" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_advance" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_tookPlayerSegment_backup" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_playerUsedCoreAbility_backup" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_random_backup" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_post_intro" ]
+	currentData.append( "diag_sp_bossFight_STS676_03_01_imc_viper" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_2segmentsLeft" ]
+	currentData.append( "diag_sp_bossFight_STS676_04_01_imc_viper" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_1segmentLeft" ]
+	currentData.append( "diag_sp_bossFight_STS676_05_01_imc_viper" )
+	// doomed
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_doomed" ]
+	currentData.append( "diag_sp_bossFight_STS676_42_01_imc_viper" )
+	// death
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_death" ]
+	currentData.append( "diag_sp_bossFight_STS676_43_01_imc_viper" )
+	// playerUsedCoreAbility
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_playerUsedCoreAbility" ]
+	currentData.append( "diag_sp_bossFight_STS676_06_01_imc_viper" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.append( "diag_sp_bossFight_STS676_07_01_imc_viper" )
+	// coreAbility
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_coreAbility" ]
+	currentData.append( "diag_sp_bossFight_STS676_08_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_39_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_15_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_09_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_11_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_40_01_imc_viper" )
+	// random
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_random" ]
+	currentData.append( "diag_sp_bossFight_STS676_10_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_19_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_10_01_imc_viper" )
+	// playerUsedCoreAbility_boss1segmentLeft
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_playerUsedCoreAbility_boss1segmentLeft" ]
+	currentData.append( "diag_sp_bossFight_STS676_12_01_imc_viper" )
+	// tookPlayerSegment_boss1segmentLeft
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_tookPlayerSegment_boss1segmentLeft" ]
+	currentData.append( "diag_sp_bossFight_STS676_13_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_14_01_imc_viper" )
+	// coreAbility_boss1segmentLeft
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_coreAbility_boss1segmentLeft" ]
+	currentData.append( "diag_sp_bossFight_STS676_09_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_11_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_40_01_imc_viper" )
+	// random_boss1segmentLeft
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_random_boss1segmentLeft" ]
+	currentData.append( "diag_sp_bossFight_STS676_16_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_17_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_18_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_19_01_imc_viper" )
+	// viper don't have coreAbility_backup
+	// retreat
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_retreat" ]
+	currentData.append( "diag_sp_bossFight_STS676_20_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_21_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_22_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_23_01_imc_viper" )
+	// advance
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_advance" ]
+	currentData.append( "diag_sp_bossFight_STS676_24_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_25_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_26_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_27_01_imc_viper" )
+	// tookPlayerSegment_backup
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_tookPlayerSegment_backup" ]
+	currentData.append( "diag_sp_bossFight_STS676_28_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_32_01_imc_viper" )
+	// playerUsedCoreAbility_backup
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_playerUsedCoreAbility_backup" ]
+	currentData.append( "diag_sp_bossFight_STS676_29_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_30_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_31_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_36_01_imc_viper" )
+	// random_backup
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_random_backup" ]
+	currentData.append( "diag_sp_bossFight_STS676_33_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_41_01_imc_viper" )
+	currentData.append( "diag_sp_bossFight_STS676_35_01_imc_viper" )
+
+	////////////////
+	/// Generic1 ///
+	////////////////
+	file.bossTitanConvData[ "Generic1" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_6segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_5segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_4segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_3segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_post_intro" ]
+	currentData.append( "diag_imc_pilot1_hc_battleStart" )
+	// 6segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_6segmentsLeft" ]
+	currentData.append( "diag_imc_pilot1_hc_lostChicket56" )
+	// 5segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_5segmentsLeft" ]
+	currentData.append( "diag_imc_pilot1_hc_lostChicket56" )
+	// 4segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_4segmentsLeft" ]
+	currentData.append( "diag_imc_pilot1_hc_lostChicket34" )
+	// 3segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_3segmentsLeft" ]
+	currentData.append( "diag_imc_pilot1_hc_lostChicket34" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_2segmentsLeft" ]
+	currentData.append( "diag_imc_pilot1_hc_lostChicket2" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_1segmentLeft" ]
+	currentData.append( "diag_imc_pilot1_hc_lostChicket1" )
+	// death
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_death" ]
+	currentData.append( "diag_imc_pilot1_hc_death" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.append( "diag_imc_pilot1_hc_plyrLostChicklet" )
+	// coreAbility_mp_titancore_shift_core
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ]
+	currentData.append( "diag_imc_pilot1_hc_coreSwordActivate" )
+	// coreAbility_mp_titancore_flight_core
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ]
+	currentData.append( "diag_imc_pilot1_hc_coreFlightActivate" )
+	// coreAbility_mp_titancore_laser_cannon
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ]
+	currentData.append( "diag_imc_pilot1_hc_coreLaserActivate" )
+	// coreAbility_mp_titancore_flame_wave
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ]
+	currentData.append( "diag_imc_pilot1_hc_coreFlameActivate" )
+	// coreAbility_mp_titancore_siege_mode
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ]
+	currentData.append( "diag_imc_pilot1_hc_coreSmartActivate" )
+	// coreAbility_mp_titancore_salvo_core
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ]
+	currentData.append( "diag_imc_pilot1_hc_coreRocketActivate" )
+
+	////////////////
+	/// Generic2 ///
+	////////////////
+	file.bossTitanConvData[ "Generic2" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_6segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_5segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_4segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_3segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_post_intro" ]
+	currentData.append( "diag_imc_pilot2_hc_battleStart" )
+	// 6segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_6segmentsLeft" ]
+	currentData.append( "diag_imc_pilot2_hc_lostChicket56" )
+	// 5segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_5segmentsLeft" ]
+	currentData.append( "diag_imc_pilot2_hc_lostChicket56" )
+	// 4segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_4segmentsLeft" ]
+	currentData.append( "diag_imc_pilot2_hc_lostChicket34" )
+	// 3segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_3segmentsLeft" ]
+	currentData.append( "diag_imc_pilot2_hc_lostChicket34" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_2segmentsLeft" ]
+	currentData.append( "diag_imc_pilot2_hc_lostChicket2" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_1segmentLeft" ]
+	currentData.append( "diag_imc_pilot2_hc_lostChicket1" )
+	// death
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_death" ]
+	currentData.append( "diag_imc_pilot2_hc_death" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.append( "diag_imc_pilot2_hc_plyrLostChicklet" )
+	// coreAbility_mp_titancore_shift_core
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ]
+	currentData.append( "diag_imc_pilot2_hc_coreSwordActivate" )
+	// coreAbility_mp_titancore_flight_core
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ]
+	currentData.append( "diag_imc_pilot2_hc_coreFlightActivate" )
+	// coreAbility_mp_titancore_laser_cannon
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ]
+	currentData.append( "diag_imc_pilot2_hc_coreLaserActivate" )
+	// coreAbility_mp_titancore_flame_wave
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ]
+	currentData.append( "diag_imc_pilot2_hc_coreFlameActivate" )
+	// coreAbility_mp_titancore_siege_mode
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ]
+	currentData.append( "diag_imc_pilot2_hc_coreSmartActivate" )
+	// coreAbility_mp_titancore_salvo_core
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ]
+	currentData.append( "diag_imc_pilot2_hc_coreRocketActivate" )
+
+	////////////////
+	/// Generic3 ///
+	////////////////
+	file.bossTitanConvData[ "Generic3" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_6segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_5segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_4segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_3segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_post_intro" ]
+	currentData.append( "diag_imc_pilot3_hc_battleStart" )
+	// 6segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_6segmentsLeft" ]
+	currentData.append( "diag_imc_pilot3_hc_lostChicket56" )
+	// 5segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_5segmentsLeft" ]
+	currentData.append( "diag_imc_pilot3_hc_lostChicket56" )
+	// 4segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_4segmentsLeft" ]
+	currentData.append( "diag_imc_pilot3_hc_lostChicket34" )
+	// 3segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_3segmentsLeft" ]
+	currentData.append( "diag_imc_pilot3_hc_lostChicket34" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_2segmentsLeft" ]
+	currentData.append( "diag_imc_pilot3_hc_lostChicket2" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_1segmentLeft" ]
+	currentData.append( "diag_imc_pilot3_hc_lostChicket1" )
+	// death
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_death" ]
+	currentData.append( "diag_imc_pilot3_hc_death" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.append( "diag_imc_pilot3_hc_plyrLostChicklet" )
+	// coreAbility_mp_titancore_shift_core
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ]
+	currentData.append( "diag_imc_pilot3_hc_coreSwordActivate" )
+	// coreAbility_mp_titancore_flight_core
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ]
+	currentData.append( "diag_imc_pilot3_hc_coreFlightActivate" )
+	// coreAbility_mp_titancore_laser_cannon
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ]
+	currentData.append( "diag_imc_pilot3_hc_coreLaserActivate" )
+	// coreAbility_mp_titancore_flame_wave
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ]
+	currentData.append( "diag_imc_pilot3_hc_coreFlameActivate" )
+	// coreAbility_mp_titancore_siege_mode
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ]
+	currentData.append( "diag_imc_pilot3_hc_coreSmartActivate" )
+	// coreAbility_mp_titancore_salvo_core
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ]
+	currentData.append( "diag_imc_pilot3_hc_coreRocketActivate" )
+
+	////////////////
+	/// Generic4 ///
+	////////////////
+	file.bossTitanConvData[ "Generic4" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_6segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_5segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_4segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_3segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_post_intro" ]
+	currentData.append( "diag_imc_pilot4_hc_battleStart" )
+	// 6segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_6segmentsLeft" ]
+	currentData.append( "diag_imc_pilot4_hc_lostChicket56" )
+	// 5segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_5segmentsLeft" ]
+	currentData.append( "diag_imc_pilot4_hc_lostChicket56" )
+	// 4segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_4segmentsLeft" ]
+	currentData.append( "diag_imc_pilot4_hc_lostChicket34" )
+	// 3segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_3segmentsLeft" ]
+	currentData.append( "diag_imc_pilot4_hc_lostChicket34" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_2segmentsLeft" ]
+	currentData.append( "diag_imc_pilot4_hc_lostChicket2" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_1segmentLeft" ]
+	currentData.append( "diag_imc_pilot4_hc_lostChicket1" )
+	// death
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_death" ]
+	currentData.append( "diag_imc_pilot4_hc_death" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.append( "diag_imc_pilot4_hc_plyrLostChicklet" )
+	// coreAbility_mp_titancore_shift_core
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ]
+	currentData.append( "diag_imc_pilot4_hc_coreSwordActivate" )
+	// coreAbility_mp_titancore_flight_core
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ]
+	currentData.append( "diag_imc_pilot4_hc_coreFlightActivate" )
+	// coreAbility_mp_titancore_laser_cannon
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ]
+	currentData.append( "diag_imc_pilot4_hc_coreLaserActivate" )
+	// coreAbility_mp_titancore_flame_wave
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ]
+	currentData.append( "diag_imc_pilot4_hc_coreFlameActivate" )
+	// coreAbility_mp_titancore_siege_mode
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ]
+	currentData.append( "diag_imc_pilot4_hc_coreSmartActivate" )
+	// coreAbility_mp_titancore_salvo_core
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ]
+	currentData.append( "diag_imc_pilot4_hc_coreRocketActivate" )
+
+	////////////////
+	/// Generic5 ///
+	////////////////
+	file.bossTitanConvData[ "Generic5" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_6segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_5segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_4segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_3segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_post_intro" ]
+	currentData.append( "diag_imc_pilot5_hc_battleStart" )
+	// 6segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_6segmentsLeft" ]
+	currentData.append( "diag_imc_pilot5_hc_lostChicket56" )
+	// 5segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_5segmentsLeft" ]
+	currentData.append( "diag_imc_pilot5_hc_lostChicket56" )
+	// 4segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_4segmentsLeft" ]
+	currentData.append( "diag_imc_pilot5_hc_lostChicket34" )
+	// 3segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_3segmentsLeft" ]
+	currentData.append( "diag_imc_pilot5_hc_lostChicket34" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_2segmentsLeft" ]
+	currentData.append( "diag_imc_pilot5_hc_lostChicket2" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_1segmentLeft" ]
+	currentData.append( "diag_imc_pilot5_hc_lostChicket1" )
+	// death
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_death" ]
+	currentData.append( "diag_imc_pilot5_hc_death" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.append( "diag_imc_pilot5_hc_plyrLostChicklet" )
+	// coreAbility_mp_titancore_shift_core
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ]
+	currentData.append( "diag_imc_pilot5_hc_coreSwordActivate" )
+	// coreAbility_mp_titancore_flight_core
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ]
+	currentData.append( "diag_imc_pilot5_hc_coreFlightActivate" )
+	// coreAbility_mp_titancore_laser_cannon
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ]
+	currentData.append( "diag_imc_pilot5_hc_coreLaserActivate" )
+	// coreAbility_mp_titancore_flame_wave
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ]
+	currentData.append( "diag_imc_pilot5_hc_coreFlameActivate" )
+	// coreAbility_mp_titancore_siege_mode
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ]
+	currentData.append( "diag_imc_pilot5_hc_coreSmartActivate" )
+	// coreAbility_mp_titancore_salvo_core
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ]
+	currentData.append( "diag_imc_pilot5_hc_coreRocketActivate" )
+
+	////////////////
+	/// Generic6 ///
+	////////////////
+	file.bossTitanConvData[ "Generic6" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_6segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_5segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_4segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_3segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_post_intro" ]
+	currentData.append( "diag_imc_pilot6_hc_battleStart" )
+	// 6segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_6segmentsLeft" ]
+	currentData.append( "diag_imc_pilot6_hc_lostChicket56" )
+	// 5segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_5segmentsLeft" ]
+	currentData.append( "diag_imc_pilot6_hc_lostChicket56" )
+	// 4segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_4segmentsLeft" ]
+	currentData.append( "diag_imc_pilot6_hc_lostChicket34" )
+	// 3segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_3segmentsLeft" ]
+	currentData.append( "diag_imc_pilot6_hc_lostChicket34" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_2segmentsLeft" ]
+	currentData.append( "diag_imc_pilot6_hc_lostChicket2" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_1segmentLeft" ]
+	currentData.append( "diag_imc_pilot6_hc_lostChicket1" )
+	// death
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_death" ]
+	currentData.append( "diag_imc_pilot6_hc_death" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.append( "diag_imc_pilot6_hc_plyrLostChicklet" )
+	// coreAbility_mp_titancore_shift_core
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ]
+	currentData.append( "diag_imc_pilot6_hc_coreSwordActivate" )
+	// coreAbility_mp_titancore_flight_core
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ]
+	currentData.append( "diag_imc_pilot6_hc_coreFlightActivate" )
+	// coreAbility_mp_titancore_laser_cannon
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ]
+	currentData.append( "diag_imc_pilot6_hc_coreLaserActivate" )
+	// coreAbility_mp_titancore_flame_wave
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ]
+	currentData.append( "diag_imc_pilot6_hc_coreFlameActivate" )
+	// coreAbility_mp_titancore_siege_mode
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ]
+	currentData.append( "diag_imc_pilot6_hc_coreSmartActivate" )
+	// coreAbility_mp_titancore_salvo_core
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ]
+	currentData.append( "diag_imc_pilot6_hc_coreRocketActivate" )
+
+	////////////////
+	/// Generic7 ///
+	////////////////
+	file.bossTitanConvData[ "Generic7" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_6segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_5segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_4segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_3segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_post_intro" ]
+	currentData.append( "diag_imc_pilot7_hc_battleStart" )
+	// 6segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_6segmentsLeft" ]
+	currentData.append( "diag_imc_pilot7_hc_lostChicket56" )
+	// 5segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_5segmentsLeft" ]
+	currentData.append( "diag_imc_pilot7_hc_lostChicket56" )
+	// 4segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_4segmentsLeft" ]
+	currentData.append( "diag_imc_pilot7_hc_lostChicket34" )
+	// 3segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_3segmentsLeft" ]
+	currentData.append( "diag_imc_pilot7_hc_lostChicket34" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_2segmentsLeft" ]
+	currentData.append( "diag_imc_pilot7_hc_lostChicket2" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_1segmentLeft" ]
+	currentData.append( "diag_imc_pilot7_hc_lostChicket1" )
+	// death
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_death" ]
+	currentData.append( "diag_imc_pilot7_hc_death" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.append( "diag_imc_pilot7_hc_plyrLostChicklet" )
+	// coreAbility_mp_titancore_shift_core
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ]
+	currentData.append( "diag_imc_pilot7_hc_coreSwordActivate" )
+	// coreAbility_mp_titancore_flight_core
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ]
+	currentData.append( "diag_imc_pilot7_hc_coreFlightActivate" )
+	// coreAbility_mp_titancore_laser_cannon
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ]
+	currentData.append( "diag_imc_pilot7_hc_coreLaserActivate" )
+	// coreAbility_mp_titancore_flame_wave
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ]
+	currentData.append( "diag_imc_pilot7_hc_coreFlameActivate" )
+	// coreAbility_mp_titancore_siege_mode
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ]
+	currentData.append( "diag_imc_pilot7_hc_coreSmartActivate" )
+	// coreAbility_mp_titancore_salvo_core
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ]
+	currentData.append( "diag_imc_pilot7_hc_coreRocketActivate" )
+
+	////////////////
+	/// Generic8 ///
+	////////////////
+	file.bossTitanConvData[ "Generic8" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_6segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_5segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_4segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_3segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_post_intro" ]
+	currentData.append( "diag_imc_pilot8_hc_battleStart" )
+	// 6segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_6segmentsLeft" ]
+	currentData.append( "diag_imc_pilot8_hc_lostChicket56" )
+	// 5segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_5segmentsLeft" ]
+	currentData.append( "diag_imc_pilot8_hc_lostChicket56" )
+	// 4segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_4segmentsLeft" ]
+	currentData.append( "diag_imc_pilot8_hc_lostChicket34" )
+	// 3segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_3segmentsLeft" ]
+	currentData.append( "diag_imc_pilot8_hc_lostChicket34" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_2segmentsLeft" ]
+	currentData.append( "diag_imc_pilot8_hc_lostChicket2" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_1segmentLeft" ]
+	currentData.append( "diag_imc_pilot8_hc_lostChicket1" )
+	// death
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_death" ]
+	currentData.append( "diag_imc_pilot8_hc_death" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.append( "diag_imc_pilot8_hc_plyrLostChicklet" )
+	// coreAbility_mp_titancore_shift_core
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ]
+	currentData.append( "diag_imc_pilot8_hc_coreSwordActivate" )
+	// coreAbility_mp_titancore_flight_core
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ]
+	currentData.append( "diag_imc_pilot8_hc_coreFlightActivate" )
+	// coreAbility_mp_titancore_laser_cannon
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ]
+	currentData.append( "diag_imc_pilot8_hc_coreLaserActivate" )
+	// coreAbility_mp_titancore_flame_wave
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ]
+	currentData.append( "diag_imc_pilot8_hc_coreFlameActivate" )
+	// coreAbility_mp_titancore_siege_mode
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ]
+	currentData.append( "diag_imc_pilot8_hc_coreSmartActivate" )
+	// coreAbility_mp_titancore_salvo_core
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ]
+	currentData.append( "diag_imc_pilot8_hc_coreRocketActivate" )
+
+	#if BOSS_TITAN_LINE_DEBUG_PRINT
+		print( "===================================================================" )
+		print( "Boss titan conversation init done!" )
+		print( "Initialized conversations: " )
+		foreach ( string bossName, table< string, array<string> > convTable in file.bossTitanConvData )
+		{
+			foreach ( string convType, array<string> convAliases in convTable )
+			{
+				print( "--------------------------------------------------------" )
+				print( "Array print: " + string( convAliases ) )
+				print( "Boss name: " + bossName )
+				print( "Type: " + convType )
+				print( "Sound Aliases: " )
+				foreach ( string alias in convAliases )
+					print( "    " + alias )
+				print( "--------------------------------------------------------" )
+			}
+		}
+		print( "===================================================================" )
+	#endif // BOSS_TITAN_LINE_DEBUG_PRINT
+}
+
+// init player table
+void function OnClientConnected( entity player )
+{
+	MpBossTitanLineReceiver emptyStruct
+	file.mpBossTitanLineReceiver[ player ] <- emptyStruct
+	file.aliasUsedTimesOnPlayer[ player ] <- {}
+	file.lastSaidLineTimeOnPlayer[ player ] <- 0.0
+	file.lastSaidLineTimesOnPlayer[ player ] <- {}
+	file.usedAliasesOnPlayer[ player ] <- []
+}
+
+// init table for boss
+void function OnBossTitanRegister( entity titan )
+{
+	//print( "Calling OnBossTitanRegister() callback! in _boss_titan_conversation.gnut" )
+	MpBossTitanLine emptyStruct
+	file.mpBossTitanConversation[ titan ] <- emptyStruct
+	file.bossNextRandomLineTime[ titan ] <- 0.0
+}
+
+void function OnBossTitanDeregister( entity titan )
+{
+	if ( titan in file.mpBossTitanConversation )
+		delete file.mpBossTitanConversation[ titan ]
+	if ( titan in file.bossNextRandomLineTime )
+		delete file.bossNextRandomLineTime[ titan ]
+}
+
+void function MpBossTitan_ConversationAdvance( entity bossTitan )
+{
+	if ( !MpBossTitan_TitanIsBoss( bossTitan ) )
+		return
+
+	MpBossTitan_PlayConversationDefault( bossTitan, "bossTitan_advance" )
+}
+
+void function MpBossTitan_ConversationRetreat( entity bossTitan )
+{
+	if ( !MpBossTitan_TitanIsBoss( bossTitan ) )
+		return
+
+	MpBossTitan_PlayConversationDefault( bossTitan, "bossTitan_retreat" )
+}
+
+void function MpBossTitan_ConversationPlayerUseCoreAbility( entity player )
+{
+	entity titan = MpBossTitan_GetNearbyBossForPlayer( player )
+	if ( titan == null )
+		return
+
+	string conv = "bossTitan_playerUsedCoreAbility"
+
+	MpBossTitan_PlayConversationDefault( titan, conv )
+}
+
+void function MpBossTitan_SetTitanEnableCoreConversation( entity titan, bool enable )
+{
+	if ( !( titan in file.mpBossTitanConversation ) ) // this is not a registered boss?
+		return
+
+	file.mpBossTitanConversation[titan].enableCoreConversation = enable
+}
+
+void function MpBossTitan_ConversationUseCoreAbility( entity bossTitan )
+{
+	if ( !MpBossTitan_TitanIsBoss( bossTitan ) )
+		return
+	// modified setting, we can disable core dialogue for specific titan
+	if ( !( bossTitan in file.mpBossTitanConversation ) ) // this is not a registered boss?
+		return
+	if ( !file.mpBossTitanConversation[bossTitan].enableCoreConversation )
+		return
+
+	string conv = "bossTitan_coreAbility"
+
+	if ( MpBossTitan_IsGenericTitan( bossTitan ) )
+	{
+		entity coreWeapon = bossTitan.GetOffhandWeapon( OFFHAND_EQUIPMENT )
+		if ( !IsValid( coreWeapon ) )
+			return
+		string coreName = coreWeapon.GetWeaponClassName()
+		conv = conv + "_" + coreName
+	}
+
+	MpBossTitan_PlayConversationDefault( bossTitan, conv, "", true )
+}
+
+void function MpBossTitan_ConversationDeath( entity bossTitan, string bossName )
+{
+	if ( !MpBossTitan_TitanIsBoss( bossTitan ) )
+		return
+
+	MpBossTitan_CancelBossConversation( bossTitan )
+	MpBossTitan_PlayConversationDefault( bossTitan, "bossTitan_death", bossName, true )
+}
+
+void function MpBossTitan_ConversationDoomed( entity bossTitan )
+{
+	if ( !MpBossTitan_TitanIsBoss( bossTitan ) )
+		return
+
+	MpBossTitan_PlayConversationDefault( bossTitan, "bossTitan_doomed", "", true )
+}
+
+// this is unused
+void function MpBossTitan_ConversationDamaged( entity bossTitan )
+{
+	if ( !MpBossTitan_TitanIsBoss( bossTitan ) )
+		return
+
+	float amplitude = RandomFloatRange( 1.5, 2.5 )
+	float frequency = 20.0
+	float duration = RandomFloatRange( 0.2, 0.4 )
+
+	MpBossTitan_PlayConversationDefault( bossTitan, "bossTitan_damage" )
+}
+
+void function MpBossTitan_ConversationTookPlayerSegment( entity victimPlayer, int currentSegment )
+{
+	entity titan = MpBossTitan_GetNearbyBossForPlayer( victimPlayer )
+	if ( titan == null )
+		return
+
+	string conv = "bossTitan_tookPlayerSegment"
+
+	MpBossTitan_PlayConversationDefault( titan, conv )
+}
+
+void function MpBossTitan_ConversationLostSegment( entity bossTitan, int currentSegment )
+{
+	float amplitude = 2.0
+	float frequency = 40.0
+	float duration = RandomFloatRange( 1.5, 2.0 )
+
+	if ( !MpBossTitan_TitanIsBoss( bossTitan ) )
+		return
+
+	if ( GetDoomedState( bossTitan ) )
+		return
+
+	string conv = ""
+
+	if ( MpBossTitan_IsGenericTitan( bossTitan ) )
+	{
+		int tabs = GetTitanCurrentRegenTab( bossTitan )
+		if ( tabs == 1 )
+			conv = "bossTitan_1segmentLeft"
+		else
+			conv = "bossTitan_" + tabs + "segmentsLeft"
+	}
+	else
+	{
+		if ( GetHealthFrac( bossTitan ) <= 0.3 )
+			conv = "bossTitan_1segmentLeft"
+		else if ( GetHealthFrac( bossTitan ) <= 0.6 )
+			conv = "bossTitan_2segmentsLeft"
+	}
+
+	if ( conv == "" )
+		return
+
+	if ( bossTitan.ContextAction_IsMeleeExecution() )
+		return
+
+	if ( !IsAlive( bossTitan ) )
+		return
+
+	MpBossTitan_PlayConversationDefault( bossTitan, conv )
+}
+
+function MpBossTitan_ConversationNoIntro( entity bossTitan )
+{
+	if ( !MpBossTitan_TitanIsBoss( bossTitan ) )
+		return
+
+	if ( IsAlive( bossTitan ) )
+		MpBossTitan_PlayConversationDefault( bossTitan, "bossTitan_post_intro" )
+
+	// intro ended, start random line
+	MpBossTitan_StartTitanRandomLines( bossTitan )
+}
+
+void function MpBossTitan_ConversationPostIntro( entity bossTitan, bool VDUEnabled )
+{
+	if ( !MpBossTitan_TitanIsBoss( bossTitan ) )
+		return
+
+	if ( VDUEnabled )
+		MpBossTitan_PlayConversationDefault( bossTitan, "bossTitan_post_intro", "", true )
+
+	// intro ended, start random line
+	thread MpBossTitan_StartTitanRandomLines( bossTitan )
+}
+
+void function MpBossTitan_StartTitanRandomLines( entity titan )
+{
+	titan.EndSignal( "OnDeath" )
+	titan.EndSignal( "Doomed" )
+	titan.EndSignal( "DeregisterBossTitan" ) // deregistering a boss titan will stop it's conversation
+	// custom signal
+	titan.Signal( "StopBossTitanRandomLines" )
+	titan.EndSignal( "StopBossTitanRandomLines" )
+
+	DelayNextBossRandomLine( titan ) // initial wait
+
+	while ( IsValid( titan ) )
+	{
+		if ( file.bossNextRandomLineTime[ titan ] < Time() && IsAlive( titan.GetEnemy() ) )
+			MpBossTitan_PlayConversationDefault( titan, "bossTitan_random" )
+
+		wait 0.5
+	}
+}
+
+void function DelayNextBossRandomLine( entity titan )
+{
+	if ( !( titan in file.bossNextRandomLineTime ) )
+		file.bossNextRandomLineTime[ titan ] <- 0.0
+	file.bossNextRandomLineTime[ titan ] = Time() + RandomFloatRange( 20, 30 )
+}
+
+void function MpBossTitan_StopTitanRandomLines( entity titan )
+{
+	titan.Signal( "StopBossTitanRandomLines" )
+}
+
+void function MpBossTitan_CancelBossConversation( entity boss )
+{
+	if ( !( boss in file.mpBossTitanConversation ) ) // this is not a registered boss?
+		return
+
+	// try to stop dialogue that may playing on a player
+	foreach ( entity player, MpBossTitanLineReceiver receiverStruct in file.mpBossTitanLineReceiver )
+	{
+		if ( !IsValid( player ) ) // player disconnted!
+			continue
+
+		entity lastSpeaker = receiverStruct.lastSpeakerTitan
+		string lastSoundAlias = receiverStruct.lastPlayedSoundAlias
+		if ( lastSpeaker == boss && lastSoundAlias != "" )
+			StopSoundOnEntity( player, lastSoundAlias ) // stop last played sound alias
+	}
+
+	boss.Signal( "CancelBossConversation" )
+}
+
+void function MpBossTitan_SetTitanConversationStyle( entity titan, int newStyle )
+{
+	if ( !( titan in file.mpBossTitanConversation ) ) // this is not a registered boss?
+		return
+
+	file.mpBossTitanConversation[titan].conversationStyle = newStyle
+}
+
+void function MpBossTitan_PlayConversationDefault( entity boss, string conv, string bossNameOverride = "", bool forceLine = false )
+{
+	if ( !( boss in file.mpBossTitanConversation ) ) // this is not a registered boss?
+		return
+
+	int conversationStyle = file.mpBossTitanConversation[boss].conversationStyle
+	switch ( conversationStyle )
+	{
+		case eBossTitanConvStyle.DISABLED:
+			break
+
+		case eBossTitanConvStyle.PLAY_TO_TARGET:
+			MpBossTitan_PlayConversationToTarget( boss, conv, bossNameOverride, forceLine )
+			break
+		case eBossTitanConvStyle.PLAY_TO_ALL:
+			MpBossTitan_PlayConversationToAll( boss, conv, bossNameOverride, forceLine )
+			break
+	}
+}
+
+void function MpBossTitan_PlayConversationToTarget( entity boss, string conv, string bossNameOverride = "", bool forceLine = false )
+{
+	if ( !( boss in file.mpBossTitanConversation ) ) // this is not a registered boss?
+		return
+
+	entity player
+	entity enemy = boss.GetEnemy()
+	if ( IsValid( enemy ) )
+	{
+		if ( enemy.IsPlayer() )
+			player = enemy
+		else if ( IsValid( GetPetTitanOwner( enemy ) ) )
+			player = GetPetTitanOwner( enemy )
+	}
+
+	if ( IsValid( player ) )
+		MpBossTitan_TryPlayConversationToPlayer( player, boss, conv, bossNameOverride, forceLine )
+}
+
+void function MpBossTitan_PlayConversationToAll( entity boss, string conv, string bossNameOverride = "", bool forceLine = false )
+{
+	if ( !( boss in file.mpBossTitanConversation ) ) // this is not a registered boss?
+		return
+
+	foreach ( entity player in GetPlayerArray() )
+		MpBossTitan_TryPlayConversationToPlayer( player, boss, conv, bossNameOverride, forceLine )
+}
+
+//  __  __    _    ___ _   _     _   _ _____ ___ _     ___ _______   __
+// |  \/  |  / \  |_ _| \ | |   | | | |_   _|_ _| |   |_ _|_   _\ \ / /
+// | |\/| | / _ \  | ||  \| |   | | | | | |  | || |    | |  | |  \ V / 
+// | |  | |/ ___ \ | || |\  |   | |_| | | |  | || |___ | |  | |   | |  
+// |_|  |_/_/   \_\___|_| \_|    \___/  |_| |___|_____|___| |_|   |_|  
+
+bool function MpBossTitan_TryPlayConversationToPlayer( entity player, entity boss, string conv, string bossNameOverride = "", bool forceLine = false )
+{
+	if ( !( boss in file.mpBossTitanConversation ) ) // this is not a registered boss?
+		return false
+
+	string name = bossNameOverride
+	float timeout = BOSS_TITAN_LINE_TIMEOUT
+	float globalTimeout = timeout
+
+	if ( bossNameOverride == "" ) // empty override name
+	{
+		name = boss.ai.bossCharacterName
+
+		if ( !MpBossTitan_IsGenericTitan( boss ) )
+		{
+			if ( conv == "bossTitan_2segmentsLeft" || conv == "bossTitan_1segmentLeft" ) // hack since bosses only have 2 lines
+				timeout *= 5
+		}
+	}
+
+	// cooldown think
+	if ( conv in file.lastSaidLineTimesOnPlayer[player] )
+	{
+		if ( Time() - file.lastSaidLineTimesOnPlayer[player][conv] < timeout && !forceLine )
+			return false
+	}
+	else
+		file.lastSaidLineTimesOnPlayer[player][conv] <- Time()
+
+	if ( !forceLine && Time() - file.lastSaidLineTimeOnPlayer[player] < globalTimeout * 0.75 )
+		return false
+
+	file.lastSaidLineTimesOnPlayer[player][conv] = Time()
+	file.lastSaidLineTimeOnPlayer[player] = Time()
+
+	#if BOSS_TITAN_LINE_DEBUG_PRINT
+		printt( "===========================================" )
+		printt( "PlayBossTitanLine:" )
+		printt( "conv: " + conv )
+		printt( "name: " + name )
+		string convName = conv + "_" + name.tolower()
+		printt( "convName: " + convName )
+		printt( "target player: " + string( player ) )
+		printt( "===========================================" )
+	#endif
+
+	// find alias from bossName and conv
+	string soundAlias = ""
+	if ( name in file.bossTitanConvData )
+	{
+		if ( conv in file.bossTitanConvData[name] )
+			soundAlias = GetBestAliasForPlayer( file.bossTitanConvData[name][conv], player )
+	}
+	if ( soundAlias == "" ) // can't find sound!
+	{
+		#if BOSS_TITAN_LINE_DEBUG_PRINT
+			print( "Can't find sound alias!" )
+		#endif
+		return false
+	}
+
+	#if BOSS_TITAN_LINE_DEBUG_PRINT
+		print( "Actual sound alias: " + soundAlias )
+	#endif
+
+	// ASH HACK:
+	if ( soundAlias == "diag_sp_BossVdu_BM112_03_01_imc_ash" ) // "Impressive...surprisingly impressive."
+	{
+		// so she doesn't say "Very disappointing. I expected so much more of you." right after saying "Impressive...surprisingly impressive."
+		file.usedAliasesOnPlayer[player].append( "diag_sp_BossVdu_BM112_27_01_imc_ash" )
+	}
+
+	// if player has last speaker valid, stop last sound
+	entity lastSpeaker = file.mpBossTitanLineReceiver[player].lastSpeakerTitan
+	if ( IsValid( lastSpeaker ) )
+	{
+		string lastSoundAlias = file.mpBossTitanLineReceiver[player].lastPlayedSoundAlias
+		if ( lastSoundAlias != "" )
+			StopSoundOnEntity( player, lastSoundAlias ) // stop last played sound alias
+	}
+
+	EmitSoundOnEntityOnlyToPlayer( player, player, soundAlias ) // emit sound on player, so we can stop last sound if needed
+	file.mpBossTitanConversation[boss].lastPlayedSoundAlias = soundAlias // update last played sound alias
+	// update last speaker
+	file.mpBossTitanLineReceiver[player].lastSpeakerTitan = boss
+	file.mpBossTitanLineReceiver[player].lastPlayedSoundAlias = soundAlias
+	// update alias used time
+	if ( !( soundAlias in file.aliasUsedTimesOnPlayer[player] ) )
+		file.aliasUsedTimesOnPlayer[player][soundAlias] <- Time()
+	else
+		file.aliasUsedTimesOnPlayer[player][soundAlias] = Time()
+
+	// if conversation succeeded, we add debounce for next random line
+	DelayNextBossRandomLine( boss )
+	return true
+}
+
+// from sh_ai_boss_titan.gnut
+// remove struct. using array<string> is enough for mp
+//string function GetBestAliasForPlayer( BossTitanConversation data, entity player )
+string function GetBestAliasForPlayer( array<string> soundAliases, entity player )
+{
+	// remove struct. using array<string> is enough for mp
+	//string alias = GetFreshAliasForPlayer( data, player )
+	string alias = GetFreshAliasForPlayer( soundAliases, player )
+	if ( alias == "" )
+	{
+		float longestTime = 0.0
+		// remove struct. using array<string> is enough for mp
+		//array<string> aliases = clone data.soundAliases
+		array<string> aliases = clone soundAliases
+		aliases.randomize()
+		foreach ( a in aliases )
+		{
+			if (!( a in file.aliasUsedTimesOnPlayer[player] ))
+			{
+				return a
+			}
+			else
+			{
+				float lastUsedDelay = Time() - file.aliasUsedTimesOnPlayer[player][a]
+				if ( lastUsedDelay > longestTime )
+				{
+					longestTime = lastUsedDelay
+					alias = a
+				}
+			}
+		}
+	}
+	else
+	{
+		file.usedAliasesOnPlayer[player].append( alias )
+	}
+
+	return alias
+}
+
+// remove struct. using array<string> is enough for mp
+//string function GetFreshAliasForPlayer( BossTitanConversation data, entity player )
+string function GetFreshAliasForPlayer( array<string> soundAliases, entity player )
+{
+	// remove struct. using array<string> is enough for mp
+	//foreach ( alias in data.soundAliases )
+	foreach ( string alias in soundAliases )
+	{
+		#if BOSS_TITAN_LINE_DEBUG_PRINT
+			print( "Current finding alias: " + alias )
+		#endif
+		if ( !file.usedAliasesOnPlayer[player].contains(alias) )
+		{
+			#if BOSS_TITAN_LINE_DEBUG_PRINT
+				print( "Alias " + alias + " is good enough to use!" )
+			#endif
+			return alias
+		}
+	}
+
+	return ""
+}

--- a/mod/scripts/vscripts/modai/_boss_titan_intro.gnut
+++ b/mod/scripts/vscripts/modai/_boss_titan_intro.gnut
@@ -1,0 +1,951 @@
+// From campaign, make it a server-side version
+global function MP_Boss_Titans_Intro_Init
+
+global function MpBossTitan_NoIntroSetup
+global function MpBossTitan_PlayBossTitanIntro
+
+// utility
+global function MpBossTitan_GetAnimationPilotProp
+
+// callbacks
+global function AddCallback_BossTitanIntroFinished
+
+const float SLAMZOOM_TIME = 1.0 // from _ai_boss_titan.gnut
+
+// debug
+const bool BOSS_TITAN_INTRO_DEBUG_PRINT = false
+
+// from sh_ai_boss_titan.gnut
+global struct BossTitanIntroData
+{
+    // exists in BossTitanData in sp, needs to be here for mp
+    string introAnimTitan
+	string introAnimPilot
+	//string introAnimTitanRef // should be removed for mp
+	string titanCameraAttachment
+    //
+
+    // below maybe no need for mp?
+	//string waitToStartFlag 	= ""
+	//bool waitForLookat 		= true
+	//bool lookatDoTrace 		= false
+	//float lookatDegrees 	= 30
+	//float lookatMinDist 	= 5100
+
+    // these are no use for mp I guess
+    // these variables are script driven, while other boss titan variables are csv(datatable) driven
+	//entity parentRef 		= null
+	//string parentAttach 	= ""
+	//bool doCockpitDisplay 	= true
+	//bool checkpointOnlyIfPlayerTitan = true
+
+    // mp specific
+    void functionref( entity ) introExtraFunction = null
+    bool pilotModelRemoved = false
+    float animForceStopTime = -1
+    // may need a "attachToTitan" or something?
+}
+
+struct
+{
+    // from sh_ai_boss_titan.gnut
+    table< string, BossTitanIntroData > bossTitanIntros
+
+    entity introPlayingTitan
+    table<entity, entity> bossTitanPilotProp
+    table<entity, float> titanIntroStartTime
+    array<entity> titanIntroActiveCameras
+    // callbacks
+    array<void functionref( entity )> introFinishedCallbacks
+} file
+
+void function MP_Boss_Titans_Intro_Init()
+{
+    if ( IsLobby() )
+		return
+
+    // initialize data(needs modded rpak)
+    InitBossTitanIntroData()
+
+    // connected player blend to intro
+    AddCallback_OnClientConnected( OnClientConnected )
+
+    // from _ai_boss_titan.gnut
+    FlagInit( "BossTitanViewFollow" )
+    RegisterSignal( "BossTitanStartAnim" )
+	RegisterSignal( "BossTitanIntroEnded" )
+}
+
+//  ___ _   _ ___ _____ ___    _    _     ___ __________     ____    _  _____  _    
+// |_ _| \ | |_ _|_   _|_ _|  / \  | |   |_ _|__  / ____|   |  _ \  / \|_   _|/ \   
+//  | ||  \| || |  | |  | |  / _ \ | |    | |  / /|  _|     | | | |/ _ \ | | / _ \  
+//  | || |\  || |  | |  | | / ___ \| |___ | | / /_| |___    | |_| / ___ \| |/ ___ \ 
+// |___|_| \_|___| |_| |___/_/   \_\_____|___/____|_____|   |____/_/   \_\_/_/   \_\
+
+// initialize data(needs modded rpak)
+void function InitBossTitanIntroData()
+{
+    // fill boss fields
+    // I can't handle datatable importing, let's just fill it by hand
+    /*
+	var dataTable = GetDataTable( $"datatable/titan_bosses.rpak" )
+	for ( int i = 0; i < GetDatatableRowCount( dataTable ); i++ )
+	{
+		string bossName	= GetDataTableString( dataTable, i, GetDataTableColumnByName( dataTable, "bossCharacter" ) )
+		print( "bossName: " + bossName )
+        BossTitanIntroData introData = AddBossTitanIntro( bossName )
+
+		introData.titanCameraAttachment	= GetDataTableString( dataTable, i, GetDataTableColumnByName( dataTable, "titanCameraAttachment" ) )
+		introData.introAnimTitan 		= GetDataTableString( dataTable, i, GetDataTableColumnByName( dataTable, "introAnimTitan" ) )
+		introData.introAnimPilot 		= GetDataTableString( dataTable, i, GetDataTableColumnByName( dataTable, "introAnimPilot" ) )
+
+        // below maybe no need for mp?
+        //introData.introAnimTitanRef 	= GetDataTableString( dataTable, i, GetDataTableColumnByName( dataTable, "introAnimTitanRef" ) )
+		//introData.waitToStartFlag 	= GetDataTableString( dataTable, i, GetDataTableColumnByName( dataTable, "waitToStartFlag" ) )
+		//introData.waitForLookat 	= GetDataTableBool( dataTable, i, GetDataTableColumnByName( dataTable, "waitForLookat" ) )
+		//introData.lookatDoTrace 	= GetDataTableBool( dataTable, i, GetDataTableColumnByName( dataTable, "lookatDoTrace" ) )
+		//introData.lookatDegrees 	= GetDataTableFloat( dataTable, i, GetDataTableColumnByName( dataTable, "lookatDegrees" ) )
+		//introData.lookatMinDist 	= GetDataTableFloat( dataTable, i, GetDataTableColumnByName( dataTable, "lookatMinDist" ) )
+	
+        // mp specific, do unused generic animation for model missing intros. may need tweak on animation length( introData.animForceStopTime )
+        // there are many boss_intro animations in pete_scripted_boss_intros.mdl:
+        // "pt_beacon_boss_intro" // richter?
+        // "pt_sewers_boss_intro" // kane?
+        // "pt_ht_boss_intro" // seems same as "pt_beacon_boss_intro"
+        // "pt_lt_boss_intro" // seems same as "pt_beacon_boss_intro"
+        // "pt_boomtown_boss_intro" // ash?
+        // maybe I should check which one is the best for each boss?
+        switch ( bossName )
+        {
+            case "Viper":
+                //introData.pilotModelRemoved = true
+                introData.introAnimPilot = "pt_ht_boss_intro" // seems same as "pt_beacon_boss_intro"
+                break
+            case "Richter":
+                //introData.pilotModelRemoved = true
+                introData.introAnimPilot = "pt_beacon_boss_intro" // richter fight is in beacon
+                break
+            case "Slone":
+                //introData.pilotModelRemoved = true
+                introData.introAnimPilot = "pt_lt_boss_intro" // seems same as "pt_beacon_boss_intro"
+                break
+            case "Kane":
+                //introData.pilotModelRemoved = true
+                introData.introAnimPilot = "pt_sewers_boss_intro" // kane fight is in sewers
+                break
+        }
+    }
+    */
+
+    BossTitanIntroData introData
+    ///////////
+	/// Ash ///
+	///////////
+    introData = AddBossTitanIntro( "Ash" )
+    introData.titanCameraAttachment	= "vehicle_driver_eyes"
+    introData.introAnimTitan 		= "lt_boomtown_boss_intro"
+    introData.introAnimPilot 		= "pt_boomtown_boss_intro"
+    introData.introExtraFunction    = AshFight_BossFightIntro
+    RegisterSignal( "AshEnteredPhaseShift" ) // signals required by intro
+
+    /////////////
+	/// Viper ///
+	/////////////
+    introData = AddBossTitanIntro( "Viper" )
+    introData.titanCameraAttachment	= "vehicle_driver_eyes"
+    introData.introAnimTitan 		= "lt_s2s_boss_intro"
+    introData.introAnimPilot 		= "pt_ht_boss_intro" // temp replacement. mp don't have animation
+    introData.pilotModelRemoved     = true // we remove pilot for this intro, since they never showed up
+    introData.introExtraFunction    = ViperFight_BossFightIntro // WIP
+    RegisterSignal( "DoCore" ) // signals required by intro
+
+    ///////////////
+	/// Richter ///
+	///////////////
+    introData = AddBossTitanIntro( "Richter" )
+    introData.titanCameraAttachment	= "vehicle_driver_eyes"
+    introData.introAnimTitan 		= "mt_richter_taunt_mt"
+    introData.introAnimPilot 		= "" // temp replacement. mp don't have animation
+    introData.pilotModelRemoved     = true // maybe do scripted model in extra function?
+    introData.introExtraFunction    = RichterFight_BossFightIntro
+
+    /////////////
+	/// Slone ///
+	/////////////
+    introData = AddBossTitanIntro( "Slone" )
+    introData.titanCameraAttachment	= "vehicle_driver_eyes"
+    introData.introAnimTitan 		= "mt_injectore_room_slone"
+    introData.introAnimPilot 		= "" // temp replacement. mp don't have animation
+    introData.pilotModelRemoved     = true // maybe do scripted model in extra function?
+    introData.introExtraFunction    = SloneFight_BossFightIntro
+
+    ////////////
+	/// Kane ///
+	////////////
+    introData = AddBossTitanIntro( "Kane" )
+    introData.titanCameraAttachment	= "vehicle_driver_eyes"
+    introData.introAnimTitan 		= "ht_Kane_boss_intro_ht"
+    introData.introAnimPilot 		= "" // temp replacement. mp don't have animation
+    introData.pilotModelRemoved     = true // maybe do scripted model in extra function?
+    introData.introExtraFunction    = KaneFight_BossFightIntro
+
+    /////////////
+	/// Blisk ///
+	/////////////
+    // seems unused and unfinished
+    introData = AddBossTitanIntro( "Blisk" )
+    introData.titanCameraAttachment	= "" // datatable don't contain this
+    introData.introAnimTitan 		= "at_dismount_stand"
+    introData.introAnimPilot 		= "pt_beacon_boss_intro"
+    //introData.introExtraFunction    = 
+}
+
+// from sh_ai_boss_titan.gnut
+BossTitanIntroData function AddBossTitanIntro( string bossName )
+{
+    BossTitanIntroData bossTitanIntroData
+	file.bossTitanIntros[ bossName ] <- bossTitanIntroData
+    return bossTitanIntroData
+}
+
+BossTitanIntroData function GetBossTitanIntroData( string bossName )
+{
+	Assert( bossName in file.bossTitanIntros )
+	return file.bossTitanIntros[ bossName ]
+}
+
+void function OnClientConnected( entity player )
+{
+    // connected player blend to intro
+    thread WaitForPlayerRespawnThenDoIntroCamera( player )
+}
+
+void function WaitForPlayerRespawnThenDoIntroCamera( entity player )
+{
+    player.EndSignal( "OnDestroy" )
+    player.WaitSignal( "OnRespawned" )
+    if ( Flag( "BossTitanViewFollow" ) )
+        thread BossTitanPlayerView( player, true ) // use other's existing camera
+}
+
+void function MpBossTitan_NoIntroSetup( entity titan )
+{
+	titan.EndSignal( "OnDestroy" )
+	titan.EndSignal( "OnDeath" )
+
+	// Wait until player sees the boss titan
+	waitthread WaitForHotdropToEnd( titan )
+	titan.WaitSignal( "OnSeeEnemy" )
+
+ 	if ( MpBossTitan_TitanVDUEnabled( titan ) )
+		MpBossTitan_ConversationNoIntro( titan )
+
+    // add via AddCallback_BossTitanIntroFinished()
+	//AddEntityCallback_OnDamaged( titan, OnBossTitanDamaged )
+	//AddTitanCallback_OnHealthSegmentLost( titan, OnBossTitanLostSegment )
+    foreach ( void functionref( entity ) callbackFunc in file.introFinishedCallbacks )
+        callbackFunc( titan )
+}
+
+void function MpBossTitan_PlayBossTitanIntro( entity titan, BossTitanIntroData ornull introData = null )
+{
+	Assert( titan.IsNPC() )
+	Assert( titan.ai.bossCharacterName != "" )
+
+	if ( introData == null )
+	{
+		BossTitanIntroData defaultData = GetBossTitanIntroData( titan.ai.bossCharacterName )
+		introData = defaultData
+	}
+
+	expect BossTitanIntroData( introData )
+
+    // player movement limiter cleanup table
+    table<entity, bool> playerHasLimitedMove = {}
+
+    OnThreadEnd
+    (
+        function(): ( titan, playerHasLimitedMove )
+        {
+            file.introPlayingTitan = null
+
+            if ( IsValid( titan ) )
+            {
+                if ( titan in file.titanIntroStartTime )
+                    delete file.titanIntroStartTime[ titan ]
+            }
+
+            foreach ( entity player, bool movementLimit in playerHasLimitedMove )
+            {
+                if ( !IsValid( player ) )
+                    continue
+                if ( !movementLimit )
+                    continue
+
+                MovementUnlockForBossTitanIntro( player )
+            }
+        }
+    )
+
+	titan.EndSignal( "OnDeath" )
+    titan.EndSignal( "OnDestroy" ) // mp specific
+
+	HideCrit( titan )
+	titan.SetValidHealthBarTarget( false )
+	titan.SetInvulnerable()
+    // disable sensing
+    titan.SetNoTarget( true )
+	titan.EnableNPCFlag( NPC_IGNORE_ALL )
+
+    // wait for hot dropping. it's a bad idea to hotdrop the boss titan
+	while ( titan.e.isHotDropping )
+		WaitFrame()
+
+	HideName( titan )
+	titan.kv.allowshoot = 0
+    titan.Hide()
+    FreezeNPC( titan ) // freeze it, we do wait
+
+    // wait for at least one player alive..
+    #if BOSS_TITAN_INTRO_DEBUG_PRINT
+        print( "Waiting for at least one player alive" )
+    #endif
+    while ( GetPlayerArray_Alive().len() == 0 )
+        WaitFrame()
+
+    // wait for all players embarked
+    #if BOSS_TITAN_INTRO_DEBUG_PRINT
+        print( "Waiting for all players embarked" )
+    #endif
+    bool embarkWaitingEnd = true
+    while ( true )
+    {
+        if ( !embarkWaitingEnd )
+        {
+            WaitFrame()
+            embarkWaitingEnd = true
+        }
+
+        foreach ( entity player in GetPlayerArray_Alive() )
+        {
+            if( IsPlayerDisembarking( player ) || IsPlayerEmbarking( player ) )
+                embarkWaitingEnd = false
+        }
+
+        if ( embarkWaitingEnd )
+            break
+    }
+
+    // wait for other titan's intro end
+    #if BOSS_TITAN_INTRO_DEBUG_PRINT
+        print( "Waiting for other titan's intro end" )
+    #endif
+    while ( IsValid( file.introPlayingTitan ) )
+    {
+        WaitFrame()
+    }
+
+    // done waiting!
+    file.introPlayingTitan = titan
+    file.titanIntroStartTime[ titan ] <- Time() // mark as titan playing intro
+    UnfreezeNPC( titan ) // unfreeze
+    titan.Show()
+    // freeze all npcs except the boss
+    thread FreezeNPCsForBossTitanIntro( titan )
+
+	// Create a ref node to animate on
+	vector refPos
+	vector refAngles
+
+    refPos = titan.GetOrigin()
+
+    // we try to get closest player's pos
+    entity closestPlayer = GetClosest( GetPlayerArray_Alive(), refPos )
+    if ( IsValid( closestPlayer ) )
+    {
+        vector vecToPlayer = Normalize( closestPlayer.GetOrigin() - titan.GetOrigin() )
+        refAngles = VectorToAngles( vecToPlayer )
+        refAngles = FlattenAngles( refAngles )
+    }
+
+	entity ref = CreateScriptRef( refPos, refAngles )
+
+	entity soul = titan.GetTitanSoul()
+	if ( IsValid( soul.soul.bubbleShield ) )
+		soul.soul.bubbleShield.Destroy()
+
+    // Freeze player and clear up the screen
+    foreach ( entity player in GetPlayerArray_Alive() )
+    {
+        MovementLockForBossTitanIntro( player )
+        playerHasLimitedMove[ player ] <- true // mark as player's movement being limited
+    }
+
+	// Do special player view movement
+	FlagSet( "BossTitanViewFollow" ) // we set later when player started camera lock
+
+	// Animate the boss titan
+    entity pilot
+    if ( !introData.pilotModelRemoved ) // model may not exist on mp
+    {
+        pilot = CreatePropDynamic( MpBossTitan_GetBossCharacterModel( titan ) )
+        SetAnimationPilotProp( titan, pilot ) // set it to titan's pilot prop
+    }
+	//SetTeam( pilot, TEAM_IMC ) // don't reset team for mp
+
+	string pilotAnimName = introData.introAnimPilot
+	string titanAnimName = introData.introAnimTitan
+    // run intro extra function
+    if ( introData.introExtraFunction != null )
+        thread introData.introExtraFunction( titan )
+
+	float introDuration = 6.0
+
+	Assert( titan.Anim_HasSequence( titanAnimName ), "Your boss titan does not have an intro animation set, or it is missing." )
+
+	introDuration = titan.GetSequenceDuration( titanAnimName )
+    // pilot model may not exist on mp, we need to skip pilot show up animations
+    if ( introData.animForceStopTime > 0 )
+        introDuration = introData.animForceStopTime
+
+	svGlobal.levelEnt.Signal( "BossTitanStartAnim" )
+
+    if ( IsValid( pilot ) ) // model may not exist on mp
+        thread PlayAnim( pilot, pilotAnimName, ref, 0.0 )
+    thread PlayAnim( titan, titanAnimName, ref, 0.0 )
+
+    foreach ( entity player in GetPlayerArray_Alive() )
+	    thread BossTitanPlayerView( player, false, titan, ref, introData.titanCameraAttachment )
+
+	wait introDuration - SLAMZOOM_TIME
+
+	// Player view returns to normal
+	FlagClear( "BossTitanViewFollow" )
+    //pilot.Destroy() // move here?
+
+	wait SLAMZOOM_TIME
+
+	// Return the player screen and movement back to normal
+    foreach ( entity player, bool movementLimit in playerHasLimitedMove )
+    {
+        if ( !IsValid( player ) ) // player may disconnted
+            continue
+        MovementUnlockForBossTitanIntro( player )
+        playerHasLimitedMove[ player ] = false // mark as player has been cleaned up movement limit
+    }
+
+    if ( IsValid( pilot ) )
+	    pilot.Destroy() // maybe move up?
+
+	if ( IsValid( titan ) )
+	{
+		titan.ClearInvulnerable()
+		titan.Solid()
+        // add via AddCallback_BossTitanIntroFinished()
+		//AddEntityCallback_OnDamaged( titan, OnBossTitanDamaged )
+		//AddTitanCallback_OnHealthSegmentLost( titan, OnBossTitanLostSegment )
+		ShowName( titan )
+		titan.SetValidHealthBarTarget( true )
+		ShowCrit( titan )
+		titan.Signal( "BossTitanIntroEnded" )
+        // run callbacks
+        foreach ( void functionref( entity ) callbackFunc in file.introFinishedCallbacks )
+            callbackFunc( titan )
+	}
+
+	wait 1.5 // removed checkpoint think
+
+	titan.kv.allowshoot = 1
+	MpBossTitan_ConversationPostIntro( titan, MpBossTitan_TitanVDUEnabled( titan ) )
+
+    // re-enable sensing
+    titan.SetNoTarget( false )
+    titan.DisableNPCFlag( NPC_IGNORE_ALL )
+
+    #if BOSS_TITAN_INTRO_DEBUG_PRINT
+        print( "Boss titan intro fully finished!" )
+    #endif
+}
+
+// freeze all npcs except the boss
+void function FreezeNPCsForBossTitanIntro( entity titan )
+{
+    // init endsignals
+    titan.EndSignal( "OnDeath" )
+    titan.EndSignal( "OnDestroy" )
+    titan.EndSignal( "BossTitanIntroEnded" )
+
+    table<entity, bool> npcBeingFrozen
+
+    OnThreadEnd
+    (
+        function(): ( npcBeingFrozen )
+        {
+            foreach ( entity npc, bool frozen in npcBeingFrozen )
+            {
+                if ( !IsAlive( npc ) )
+                    continue
+
+                if ( frozen )
+                    UnfreezeNPC( npc )
+            }
+        }
+    )
+
+    while ( true )
+    {
+        foreach ( entity npc in GetNPCArray() )
+        {
+            if ( !IsAlive( npc ) )
+                continue
+            // main check
+            if ( npc == titan )
+                continue
+
+            if ( npc.ContextAction_IsBusy() ) // context action check. animation npcs should be set to busy!
+                continue
+
+            if ( !NPCIsFrozen( npc ) )
+            {
+                if ( !( npc in npcBeingFrozen ) )
+                    npcBeingFrozen[npc] <- true
+                FreezeNPC( npc )
+            }
+        }
+
+        WaitFrame()
+    }
+}
+
+void function MovementLockForBossTitanIntro( entity player )
+{
+    #if BOSS_TITAN_INTRO_DEBUG_PRINT
+        print( "Locking movement for player: " + string( player ) )
+    #endif
+    player.Hide()
+    player.SetVelocity( <0,0,0> )
+    player.FreezeControlsOnServer()
+    //player.SetNoTarget( true )
+    player.SetInvulnerable()
+}
+
+void function MovementUnlockForBossTitanIntro( entity player )
+{
+    #if BOSS_TITAN_INTRO_DEBUG_PRINT
+        print( "Unlocking movement for player: " + string( player ) )
+    #endif
+    player.UnfreezeControlsOnServer()
+    //player.SetNoTarget( false )
+    player.ClearInvulnerable()
+    player.Show()
+}
+
+void function BossTitanPlayerView( entity player, bool useExistingMover, entity titan = null, entity ref = null, string titanCameraAttachment = "" )
+{
+    // fix for titans
+    if ( !IsValid( titan ) && !IsValid( GetNewestIntroTitan() ) )
+        return
+
+    if ( !IsValid( titan ) )
+        titan = GetNewestIntroTitan()
+
+    EmitSoundOnEntityOnlyToPlayer( player, player, "Menu_CampaignSummary_TitanUnlocked" )
+
+	player.EndSignal( "OnDeath" )
+    player.EndSignal( "OnDestroy" ) // mp specific
+
+    titan.EndSignal( "OnDeath" )
+    titan.EndSignal( "OnDestroy" ) // mp specific
+
+    if ( useExistingMover ) // use exsiting mover for new connected player
+    {
+        // save things for later we restore
+        table settingsToRestore = {
+            moverStartAng = player.CameraAngles()
+        }
+
+        entity camera = FindBestActiveIntroCamera( titan )
+        if ( !IsValid( camera ) ) // camera invalid!
+            return
+        camera.EndSignal( "OnDestroy" ) // camera gets destroyed when it finished play
+        player.SetViewEntity( camera, true )
+        player.SetPredictionEnabled( false )
+
+        OnThreadEnd
+        (
+            function(): ( player, settingsToRestore )
+            {
+                if ( IsValid( player ) )
+                {
+                    player.SetPredictionEnabled( true )
+                    player.ClearParent()
+                    player.ClearViewEntity()
+
+                    ClearPlayerAnimViewEntity( player )
+                    player.SnapEyeAngles( expect vector( settingsToRestore.moverStartAng ) )
+
+                    // clean up
+                    ClearBossTitanViewPlayerEffect( player )
+                    MovementUnlockForBossTitanIntro( player )
+
+                    EmitSoundOnEntityOnlyToPlayer( player, player, "UI_Lobby_RankChip_Disable" )
+                }
+            }
+        )
+
+        
+        MovementLockForBossTitanIntro( player ) // needs to fix movement lock
+        BossTitanViewPlayerEffect( player ) // add effect
+
+        WaitForever()
+    }
+    else // normal behavior
+    {
+        bool hasTitanCameraAttachment = titanCameraAttachment != ""
+
+        vector moverStartPos = player.CameraPosition()
+
+        vector camFeetDiff = < 0,0,-185 >//player.GetOrigin() - player.CameraPosition()
+
+        vector moverStartAng = player.CameraAngles()
+        entity mover = CreateScriptMover( moverStartPos, moverStartAng )
+
+        // player.SnapEyeAngles( moverStartAng )
+        // player.SetParent( mover, "", true )
+        // ViewConeZero( player )
+
+        entity camera = CreateEntity( "point_viewcontrol" )
+        camera.kv.spawnflags = 56 // infinite hold time, snap to goal angles, make player non-solid
+
+        camera.SetOrigin( player.CameraPosition() )
+        camera.SetAngles( player.CameraAngles() )
+        DispatchSpawn( camera )
+        UpdateTitanIntroActiveCamera( camera ) // add to camera array
+
+        camera.SetParent( mover, "", false )
+
+        OnThreadEnd(
+        function() : ( player, titan, mover, camera )
+            {
+                if ( IsValid( camera ) )
+                {
+                    camera.Destroy()
+                }
+
+                mover.Destroy()
+
+                if ( IsValid( player ) )
+                {
+                    player.ClearParent()
+                    player.ClearViewEntity()
+                    RemoveCinematicFlag( player, CE_FLAG_HIDE_MAIN_HUD )
+                    RemoveCinematicFlag( player, CE_FLAG_TITAN_3P_CAM )
+                }
+            }
+        )
+
+        // Slam Zoom In
+        float slamZoomTime = SLAMZOOM_TIME
+        float slamZoomTimeAccel = 0.3
+        float slamZoomTimeDecel = 0.3
+        vector viewOffset = < 200, 100, 160 >
+
+        vector viewPos = ref.GetOrigin() + ( AnglesToForward( ref.GetAngles() ) * viewOffset.x ) + ( AnglesToRight( ref.GetAngles() ) * viewOffset.y ) + ( AnglesToUp( ref.GetAngles() ) * viewOffset.z )
+        vector viewAngles = ref.GetAngles() + <0,180,0>
+        if ( hasTitanCameraAttachment )
+        {
+            WaitFrame()
+            int titanCameraAttachmentID = titan.LookupAttachment( titanCameraAttachment )
+            viewPos = titan.GetAttachmentOrigin( titanCameraAttachmentID )
+            viewAngles = titan.GetAttachmentAngles( titanCameraAttachmentID )
+        }
+
+        float blendTime = 0.5
+        float waittime = 0.3
+        float moveTime = slamZoomTime - blendTime - waittime
+
+        float startTime = Time()
+
+        player.SetVelocity( < 0,0,0 > )
+        player.MakeInvisible()
+        HolsterAndDisableWeapons( player )
+
+        wait waittime // wait for the AI to blend into the anim
+
+        AddCinematicFlag( player, CE_FLAG_HIDE_MAIN_HUD )
+        AddCinematicFlag( player, CE_FLAG_TITAN_3P_CAM )
+
+        mover.SetOrigin( player.CameraPosition() )
+        mover.SetAngles( player.CameraAngles() )
+        player.SetViewEntity( camera, true )
+
+        player.SetPredictionEnabled( false )
+        OnThreadEnd(
+        function() : ( player )
+            {
+                if ( IsValid( player ) )
+                    player.SetPredictionEnabled( true )
+            }
+        )
+
+        while ( Time() - startTime < moveTime )
+        {
+            if ( hasTitanCameraAttachment )
+            {
+                int titanCameraAttachmentID = titan.LookupAttachment( titanCameraAttachment )
+                viewPos = titan.GetAttachmentOrigin( titanCameraAttachmentID )
+                viewAngles = titan.GetAttachmentAngles( titanCameraAttachmentID )
+            }
+            mover.NonPhysicsMoveTo( viewPos, moveTime - (Time() - startTime), 0, 0 )
+            mover.NonPhysicsRotateTo( viewAngles, moveTime - (Time() - startTime), 0, 0 )
+            wait 0.1
+        }
+
+        if ( hasTitanCameraAttachment )
+        {
+            mover.SetParent( titan, titanCameraAttachment, false, blendTime )
+        }
+
+        wait 0.5
+
+        int tagID = titan.LookupAttachment( "CHESTFOCUS" )
+        while ( Flag( "BossTitanViewFollow" ) )
+        {
+            vector lookVec = Normalize( titan.GetAttachmentOrigin( tagID ) - mover.GetOrigin() )
+            vector angles = VectorToAngles( lookVec )
+            if ( !hasTitanCameraAttachment )
+                mover.NonPhysicsRotateTo( angles, 0.2, 0.0, 0.0 )
+            WaitFrame()
+        }
+
+        // Slam Zoom Out
+
+        mover.ClearParent()
+
+        startTime = Time()
+        while ( Time() - startTime < slamZoomTime )
+        {
+            moverStartPos = player.GetOrigin() - camFeetDiff
+            moverStartAng = FlattenAngles( player.GetAngles() )
+            mover.NonPhysicsMoveTo( moverStartPos, slamZoomTime - (Time() - startTime), 0, 0 )
+            mover.NonPhysicsRotateTo( moverStartAng, slamZoomTime - (Time() - startTime), 0, 0 )
+            wait 0.1
+        }
+
+        // mover.NonPhysicsMoveTo( moverStartPos, slamZoomTime, slamZoomTimeDecel, slamZoomTimeAccel )
+        // mover.NonPhysicsRotateTo( moverStartAng, slamZoomTime, slamZoomTimeDecel, slamZoomTimeAccel )
+        // wait slamZoomTime
+
+        ClearPlayerAnimViewEntity( player )
+        player.SnapEyeAngles( moverStartAng )
+        DeployAndEnableWeapons( player )
+        player.MakeVisible()
+
+        EmitSoundOnEntityOnlyToPlayer( player, player, "UI_Lobby_RankChip_Disable" )
+    }
+}
+
+void function BossTitanViewPlayerEffect( entity player )
+{
+    // adding screen effect
+    AddCinematicFlag( player, CE_FLAG_HIDE_MAIN_HUD )
+    AddCinematicFlag( player, CE_FLAG_TITAN_3P_CAM )
+
+    // limit movement
+    player.SetVelocity( < 0,0,0 > )
+    player.MakeInvisible()
+    HolsterAndDisableWeapons( player )
+}
+
+void function ClearBossTitanViewPlayerEffect( entity player )
+{
+    RemoveCinematicFlag( player, CE_FLAG_HIDE_MAIN_HUD )
+    RemoveCinematicFlag( player, CE_FLAG_TITAN_3P_CAM )
+    player.MakeVisible()
+    DeployAndEnableWeapons( player )
+}
+
+entity function GetNewestIntroTitan()
+{
+    entity newTitan
+    float curIntroStartTime = -1
+    foreach ( entity titan, float startTime in file.titanIntroStartTime )
+    {
+        if ( !IsAlive( titan ) )
+            continue
+
+        if ( curIntroStartTime == -1 || startTime < curIntroStartTime ) // we update on first loop or finding other intro titans
+        {
+            newTitan = titan
+            curIntroStartTime = startTime
+        }
+    }
+
+    //print( "Newest intro titan: " + string( newTitan ) )
+    return newTitan
+}
+
+void function UpdateTitanIntroActiveCamera( entity newCamera )
+{
+    ArrayRemoveInvalid( file.titanIntroActiveCameras )
+    if ( !file.titanIntroActiveCameras.contains( newCamera ) )
+        file.titanIntroActiveCameras.append( newCamera )
+}
+
+entity function FindBestActiveIntroCamera( entity titan )
+{
+    ArrayRemoveInvalid( file.titanIntroActiveCameras )
+    vector origin = titan.GetOrigin()
+    if ( file.titanIntroActiveCameras.len() > 0 )
+    {
+        entity camera = GetClosest( file.titanIntroActiveCameras, origin )
+        //print( "Active intro camera: " + string( camera ) )
+        return camera
+    }
+
+    return null
+}
+
+void function SetAnimationPilotProp( entity titan, entity prop )
+{
+    if ( !( titan in file.bossTitanPilotProp ) )
+        file.bossTitanPilotProp[ titan ] <- null
+    file.bossTitanPilotProp[ titan ] = prop
+}
+
+entity function MpBossTitan_GetAnimationPilotProp( entity titan )
+{
+    if ( !( titan in file.bossTitanPilotProp ) )
+        return null
+    return file.bossTitanPilotProp[ titan ]
+}
+
+// callbacks
+void function AddCallback_BossTitanIntroFinished( void functionref( entity ) callbackFunc )
+{
+    if ( !file.introFinishedCallbacks.contains( callbackFunc ) )
+        file.introFinishedCallbacks.append( callbackFunc )
+}
+
+
+//  ____  _____ _____ _   _   _ _   _____     ___ _   _ _____ ____   ___  ____  
+// |  _ \| ____|  ___/ \ | | | | | |_   _|   |_ _| \ | |_   _|  _ \ / _ \/ ___| 
+// | | | |  _| | |_ / _ \| | | | |   | |      | ||  \| | | | | |_) | | | \___ \ 
+// | |_| | |___|  _/ ___ \ |_| | |___| |      | || |\  | | | |  _ <| |_| |___) |
+// |____/|_____|_|/_/   \_\___/|_____|_|     |___|_| \_| |_| |_| \_\\___/|____/ 
+
+// from sp_boomtown_end.nut
+void function AshFight_BossFightIntro( entity titan )
+{
+    titan.EndSignal( "OnDestroy" )
+
+    //titan.SetTitle( "#BOSSNAME_ASH" )
+	//HideName( titan )
+    titan.EnableNPCFlag( NPC_ALLOW_PATROL | NPC_ALLOW_INVESTIGATE | NPC_ALLOW_HAND_SIGNALS )
+
+	// Store off Ash's weapon and give it back later in the animation
+	entity weapon = titan.GetActiveWeapon()
+	array<string> mods = weapon.GetMods()
+	string weaponName = weapon.GetWeaponClassName()
+	titan.TakeActiveWeapon()
+
+	// Get spawn a dummy weapon model that is holstered
+	string attachTag    = "RIFLE_HOLSTER"
+	asset weaponModel   = weapon.GetModelName()
+	int attachID 		= titan.LookupAttachment( attachTag )
+	vector attachPos    = titan.GetAttachmentOrigin( attachID )
+	vector attachAngles = titan.GetAttachmentAngles( attachID )
+	entity dummyGun	    = CreatePropDynamic( weaponModel, attachPos, attachAngles )
+	dummyGun.SetParent( titan, attachTag, false, 0 )
+
+    // mp adding: want to hide pilot prop for a phase shift intro
+    entity pilot = MpBossTitan_GetAnimationPilotProp( titan )
+    if ( IsValid( pilot ) )
+        pilot.Hide()
+
+    titan.WaitSignal( "StopPhaseShift" ) // signal works for animevent phase shift
+    if ( IsValid( pilot ) )
+        pilot.Show()
+
+    WaitSignal( titan, "AshEnteredPhaseShift" )
+
+	PhaseShift( titan, 0, 1.5 )
+    // want to hide pilot prop for phase shift
+    if ( IsValid( pilot ) )
+        pilot.Hide()
+
+	wait 1.0
+
+    // Re-enable real weapon & destroy the dummy prop
+	titan.GiveWeapon( weaponName, mods )
+	dummyGun.Destroy()
+
+    //titan.SetTitle( "#BOSSNAME_ASH" )
+	//ShowName( titan )
+}
+
+// WIP: add ViperCoreThink() from sp_s2s.nut
+void function ViperFight_BossFightIntro( entity titan )
+{
+
+}
+
+// WIP: do scripted prop think(use some animations similar, or use idle animation) and dialogue fix
+void function RichterFight_BossFightIntro( entity titan )
+{
+
+}
+
+// WIP: do scripted prop think(use some animations similar, or use idle animation) and dialogue fix
+// play together with blisk titan model. maybe... slone intro will spawn blisk, blisk intro will spawn slone?
+void function SloneFight_BossFightIntro( entity titan )
+{
+
+}
+
+// WIP: needs to figure out ref usage
+void function KaneFight_BossFightIntro( entity titan )
+{
+    /*
+    titan.EndSignal( "OnDestroy" )
+
+    // Spawn militia titan
+    entity militiaTitan = CreateNPCTitan( "npc_titan_atlas", 3, titan.GetOrigin(), titan.GetAngles() )
+	SetSpawnOption_AISettings( militiaTitan , "npc_titan_atlas_tracker" )
+	DispatchSpawn( militiaTitan )
+
+	militiaTitan.SetSkin( 2 ) // militia skin
+	militiaTitan.SetInvulnerable()
+	militiaTitan.ContextAction_SetBusy() // won't be freezed by intro
+	militiaTitan.EnableNPCFlag( NPC_IGNORE_ALL )
+	militiaTitan.SetNoTarget( true )
+	militiaTitan.SetAIObstacle( true )
+	Highlight_ClearFriendlyHighlight( militiaTitan )
+	DisableTitanRodeo( militiaTitan )
+	HideName( militiaTitan )
+
+    DoomTitan( militiaTitan ) // maybe just instant set it to doomed state bodygroup?
+
+    //militia:  origin < -4391.29, -6446.53, 3322 > angles < 0, -90, 0 >
+	//ref:      origin < -4658.18, -6594.47, 3322 > angles < 0, 0, 0 >
+	//kane:     origin < -4401.29, -6605.44, 3322 > angles < 0, 90, 0 >
+    vector refPos = titan.GetOrigin()
+    vector refAngles = titan.GetAngles()
+    refAngles.y = ClampAngle( refAngles.y + 180 )
+    entity ref = CreateScriptRef( refPos, refAngles )
+    thread PlayAnim( militiaTitan, "mt_Kane_boss_intro_mt", ref )
+
+    // Spawn the militia pilot
+	entity pilot = CreatePropDynamic( $"models/humans/pilots/sp_medium_reaper_m.mdl", militiaTitan.GetOrigin(), militiaTitan.GetAngles(), 6, 20000 )
+	thread PlayAnim( pilot, "pt_Kane_boss_intro_pilot", ref )
+
+    WaitSignal( titan, "BossTitanIntroEnded" )
+    thread PlayAnim( militiaTitan, "mt_Kane_boss_intro_mt_idle", ref )
+
+    int fx = GetParticleSystemIndex( $"xo_exp_death" )
+	StartParticleEffectInWorld( fx, < -4391, -6446, 3322 >, <0, 0, 0> ) // Play fx exactly where we need it to cover the model delete.
+    militiaTitan.Destroy()
+
+    ref.Destroy()
+    */
+}

--- a/mod/scripts/vscripts/modai/_boss_titan_mp.gnut
+++ b/mod/scripts/vscripts/modai/_boss_titan_mp.gnut
@@ -1,0 +1,637 @@
+// From campaign, make it a server-side and mp-only version
+#if MP
+global function Multiplayer_BossTitan_Init
+
+// add more shared utilities. mostly from sh_ai_boss_titan.gnut
+global function MpBossTitan_Register
+global function MpBossTitan_Deregister
+global function MpBossTitan_GetNearbyBossForPlayer
+global function MpBossTitan_IsGenericTitan
+
+// callbacks
+global function AddCallback_OnMpBossTitanRegister
+global function AddCallback_OnMpBosstitanDeregister
+
+// remove globalize, mp has no-where used it
+global function MpBossTitan_TitanVDUEnabled
+global function MpBossTitan_TitanIsBoss
+global function MpBossTitan_GetBossCharacterModel
+
+// titan settings
+global function MpBossTitan_SetDamageScale
+global function MpBossTitan_SetDamageReductionScale
+
+// use in-file callbacks instead of globalizing functions everywhere
+//global function BossTitanRetreat
+//global function BossTitanAdvance
+//global function IsMercTitan
+//global function GetMercCharacterID
+
+// why are these consts have to be globalized?
+//global const float BOSS_TITAN_CORE_DAMAGE_SCALER_LOW = 0.6
+//global const float BOSS_TITAN_CORE_DAMAGE_SCALER = 0.5
+
+// from sh_ai_boss_titan.gnut
+global struct BossTitanData
+{
+	int bossID
+	string bossTitle
+	// should be in struct BossTitanIntroData for mp
+	//string introAnimTitan
+	//string introAnimPilot
+	//string introAnimTitanRef
+	//string titanCameraAttachment
+	asset characterModel
+}
+
+struct
+{
+	// callbacks
+	array<void functionref( entity )> bossTitanRegisterCallbacks
+	array<void functionref( entity )> bossTitanDeregisterCallbacks
+	// titan settings
+	table<entity, float> bossTitanDamageScale
+	table<entity, float> bossTitanDamageReductionScale
+
+	// from sh_ai_boss_titan.gnut
+	table< string, BossTitanData > bossTitans
+} file
+
+void function Multiplayer_BossTitan_Init()
+{
+	//if ( IsMultiplayer() )
+	//	return
+	if ( IsLobby() )
+		return
+
+	// initialize data(needs modded rpak)
+	InitBossTitanData()
+
+	AddDamageByCallback( "npc_titan", OnNpcTitanDealDamage )
+	AddSpawnCallback( "npc_titan", NPCTitanSpawned )
+	AddDeathCallback( "npc_titan", OnBossTitanDeath )
+	AddCallback_OnTitanDoomed( OnBossTitanDoomed )
+	AddCallback_OnTitanHealthSegmentLost( OnTitanLostSegment )
+
+	AddSyncedMeleeServerCallback( GetSyncedMeleeChooser( "titan", "titan" ), OnBossTitanExecuted )
+
+	PrecacheParticleSystem( $"P_VDU_mflash" )
+
+	// signals from sh_ai_boss_titan
+	RegisterSignal( "DeregisterBossTitan" )
+
+	// modified callbacks in _conversation_schedule.gnut
+	AddCallback_CodeDialogue( eCodeDialogueID.TAKE_COVER_FROM_ENEMY, BossTitanRetreat )
+	AddCallback_CodeDialogue( eCodeDialogueID.CHASE_ENEMY, BossTitanAdvance )
+
+	AddCallback_BossTitanIntroFinished( OnBossTitanIntroFinished )
+	// modified callback in sh_titancore_utility.gnut
+	AddCallback_OnTitanCoreUsed( OnTitanCoreUsed )
+}
+
+
+
+//  ___ _   _ ___ _____ ___    _    _     ___ __________     ____    _  _____  _    
+// |_ _| \ | |_ _|_   _|_ _|  / \  | |   |_ _|__  / ____|   |  _ \  / \|_   _|/ \   
+//  | ||  \| || |  | |  | |  / _ \ | |    | |  / /|  _|     | | | |/ _ \ | | / _ \  
+//  | || |\  || |  | |  | | / ___ \| |___ | | / /_| |___    | |_| / ___ \| |/ ___ \ 
+// |___|_| \_|___| |_| |___/_/   \_\_____|___/____|_____|   |____/_/   \_\_/_/   \_\
+
+// initialize data(needs modded rpak)
+void function InitBossTitanData()
+{
+	// fill boss fields
+	// I can't handle datatable importing, let's just fill it by hand
+	/*
+	var dataTable = GetDataTable( $"datatable/titan_bosses.rpak" )
+	for ( int i = 0; i < GetDatatableRowCount( dataTable ); i++ )
+	{
+		string bossName	= GetDataTableString( dataTable, i, GetDataTableColumnByName( dataTable, "bossCharacter" ) )
+		print( "bossName: " + bossName )
+		BossTitanData bossTitanData = AddBossTitan( bossName )
+
+		bossTitanData.bossTitle 			= GetDataTableString( dataTable, i, GetDataTableColumnByName( dataTable, "bossTitle" ) )
+		bossTitanData.characterModel 		= GetDataTableAsset( dataTable, i, GetDataTableColumnByName( dataTable, "pilotModel" ) )
+		print( "characterModel: " + string( bossTitanData.characterModel ) )
+
+		// mp specific replacement model
+        switch ( bossName )
+        {
+			// only sp pilot models included pete_scripted_boss_intros.mdl, which contains generic intro animatioins
+            case "Viper":
+                //bossTitanData.characterModel = $"models/humans/pilots/pilot_medium_reaper_m.mdl" // PulseBlade Male
+                bossTitanData.characterModel = $"models/humans/pilots/sp_medium_stalker_m.mdl"
+				break
+            case "Richter":
+                //bossTitanData.characterModel = $"models/humans/pilots/pilot_heavy_drex_m.mdl" // Cloak Male
+                bossTitanData.characterModel = $"models/humans/pilots/sp_medium_stalker_m.mdl"
+				break
+            case "Slone":
+                //bossTitanData.characterModel = $"models/humans/pilots/pilot_medium_stalker_f.mdl" // Holopilot Female
+                bossTitanData.characterModel = $"models/humans/pilots/sp_medium_geist_f.mdl"
+				break
+            case "Kane":
+                //bossTitanData.characterModel = $"models/humans/pilots/pilot_heavy_roog_m.mdl" // A-Wall Male
+                bossTitanData.characterModel = $"models/humans/pilots/sp_medium_stalker_m.mdl"
+				break
+        }
+	}
+	*/
+
+	BossTitanData bossTitanData
+	///////////
+	/// Ash ///
+	///////////
+	bossTitanData = AddBossTitan( "Ash" )
+	bossTitanData.bossTitle = "#BOSSNAME_ASH"
+	bossTitanData.characterModel = $"models/Humans/heroes/imc_hero_ash.mdl"
+
+	/////////////
+	/// Viper ///
+	/////////////
+	bossTitanData = AddBossTitan( "Viper" )
+	bossTitanData.bossTitle = "#BOSSNAME_VIPER"
+	//bossTitanData.characterModel = $"models/humans/heroes/imc_hero_viper.mdl"
+	// temp replacement. mp don't have viper model, in intro just let them use idle animation
+	// sp models do included pete_scripted_boss_intros.mdl, but it has no suitable animation
+	bossTitanData.characterModel = $"models/humans/pilots/pilot_medium_reaper_m.mdl" // PulseBlade Male
+
+	///////////////
+	/// Richter ///
+	///////////////
+	bossTitanData = AddBossTitan( "Richter" )
+	bossTitanData.bossTitle = "#BOSSNAME_RICHTER"
+	//bossTitanData.characterModel = $"models/humans/heroes/imc_hero_richter.mdl"
+	// temp replacement. mp don't have richter model, in intro just let them use idle animation
+	// sp models do included pete_scripted_boss_intros.mdl, but it has no suitable animation
+	bossTitanData.characterModel = $"models/humans/pilots/pilot_heavy_drex_m.mdl" // Cloak Male
+
+	/////////////
+	/// Slone ///
+	/////////////
+	bossTitanData = AddBossTitan( "Slone" )
+	bossTitanData.bossTitle = "#BOSSNAME_SLONE"
+	//bossTitanData.characterModel = $"models/Humans/heroes/imc_hero_slone.mdl"
+	// temp replacement. mp don't have slone model, in intro just let them use idle animation
+	// sp models do included pete_scripted_boss_intros.mdl, but it has no suitable animation
+	bossTitanData.characterModel = $"models/humans/pilots/pilot_medium_stalker_f.mdl" // Holopilot Female
+
+	////////////
+	/// Kane ///
+	////////////
+	bossTitanData = AddBossTitan( "Kane" )
+	bossTitanData.bossTitle = "#BOSSNAME_KANE"
+	//bossTitanData.characterModel = $"models/Humans/heroes/imc_hero_kane.mdl"
+	// temp replacement. mp don't have kane model, in intro just let them use idle animation
+	// sp models do included pete_scripted_boss_intros.mdl, but it has no suitable animation
+	bossTitanData.characterModel = $"models/humans/pilots/pilot_heavy_roog_m.mdl" // A-Wall Male
+
+	/////////////
+	/// Blisk ///
+	/////////////
+	bossTitanData = AddBossTitan( "Blisk" )
+	bossTitanData.bossTitle = "#BOSSNAME_BLISK"
+	bossTitanData.characterModel = $"models/Humans/heroes/imc_hero_blisk.mdl"
+}
+
+BossTitanData function AddBossTitan( string bossName )
+{
+	Assert( !( bossName in file.bossTitans ) )
+	BossTitanData bossTitanData
+	bossTitanData.bossID = file.bossTitans.len()
+	file.bossTitans[ bossName ] <- bossTitanData
+	return bossTitanData
+}
+
+
+
+//   ____    _    _     _     ____    _    ____ _  ______  
+//  / ___|  / \  | |   | |   | __ )  / \  / ___| |/ / ___| 
+// | |     / _ \ | |   | |   |  _ \ / _ \| |   | ' /\___ \ 
+// | |___ / ___ \| |___| |___| |_) / ___ \ |___| . \ ___) |
+//  \____/_/   \_\_____|_____|____/_/   \_\____|_|\_\____/ 
+
+void function OnBossTitanExecuted( SyncedMeleeChooser actions, SyncedMelee action, entity attacker, entity victim )
+{
+	if ( victim.IsNPC() && IsVDUTitan( victim ) && MpBossTitan_TitanVDUEnabled( victim ) )
+	{
+		if ( IsMercTitan( victim ) )
+		{
+			string name = victim.ai.bossCharacterName == "" ? "Generic1" : victim.ai.bossCharacterName
+			MpBossTitan_ConversationDeath( victim, name )
+		}
+	}
+}
+
+void function OnBossTitanDeath( entity titan, var damageInfo )
+{
+	int damageSourceId = DamageInfo_GetDamageSourceIdentifier( damageInfo )
+	if ( damageSourceId == eDamageSourceId.titan_execution ) // executions handled in OnBossTitanExecuted()
+		return
+
+	entity soul = titan.GetTitanSoul()
+	if ( soul.IsEjecting() ) // boss pilot is not dying, they ejected
+		return
+
+	if ( IsVDUTitan( titan ) && MpBossTitan_TitanVDUEnabled( titan ) )
+	{
+		if ( IsMercTitan( titan ) )
+		{
+			string name = titan.ai.bossCharacterName == "" ? "Generic1" : titan.ai.bossCharacterName
+			MpBossTitan_ConversationDeath( titan, name )
+		}
+	}
+}
+
+void function OnBossTitanDoomed( entity titan, var damageInfo )
+{
+	if ( IsVDUTitan( titan ) && MpBossTitan_TitanVDUEnabled( titan ) )
+	{
+		if ( IsMercTitan( titan ) )
+			MpBossTitan_ConversationDoomed( titan )
+	}
+}
+
+void function OnNpcTitanDealDamage( entity titan, var damageInfo )
+{
+	entity attacker = DamageInfo_GetAttacker( damageInfo )
+	if ( IsValid( attacker ) )
+	{
+		if ( attacker in file.bossTitanDamageScale )
+			DamageInfo_ScaleDamage( damageInfo, file.bossTitanDamageScale[ attacker ] )
+	}
+}
+
+// hardcoded hell
+const float BOSS_TITAN_CORE_DAMAGE_SCALER_LOW = 0.6
+const float BOSS_TITAN_CORE_DAMAGE_SCALER = 0.5
+
+void function OnBossTitanCoreMitigation( entity titan, var damageInfo )
+{
+	int damageSourceID = DamageInfo_GetDamageSourceIdentifier( damageInfo )
+	switch ( damageSourceID )
+	{
+		case eDamageSourceId.mp_titancore_salvo_core:
+			DamageInfo_ScaleDamage( damageInfo, BOSS_TITAN_CORE_DAMAGE_SCALER_LOW )
+			return
+
+		// case eDamageSourceId.mp_titancore_laser_cannon: laser core handles this in mp_titanweapon_lasercannon.nut
+		case eDamageSourceId.mp_titancore_flame_wave:
+		case eDamageSourceId.mp_titancore_flame_wave_secondary:
+		case eDamageSourceId.mp_titancore_shift_core:
+		case eDamageSourceId.mp_titanweapon_flightcore_rockets:
+		case eDamageSourceId.mp_titancore_amp_core:
+		case damagedef_nuclear_core:
+			DamageInfo_ScaleDamage( damageInfo, BOSS_TITAN_CORE_DAMAGE_SCALER )
+			return
+	}
+
+	// SMART CORE
+	array<string> weaponMods = GetWeaponModsFromDamageInfo( damageInfo )
+	if ( weaponMods.contains( "Smart_Core" ) )
+	{
+		DamageInfo_ScaleDamage( damageInfo, BOSS_TITAN_CORE_DAMAGE_SCALER )
+		// DamageInfo_ScaleDamage( damageInfo, BOSS_TITAN_CORE_DAMAGE_SCALER_LOW )
+		return
+	}
+}
+
+// won't influence shield damage
+void function BossTitanDamageReduction( entity titan, var damageInfo )
+{
+	if ( titan in file.bossTitanDamageReductionScale )
+	{
+		float damage = DamageInfo_GetDamage( damageInfo )
+		float damageTaken = 1.0 - file.bossTitanDamageReductionScale[ titan ]
+		DamageInfo_ScaleDamage( damageInfo, damageTaken )
+
+		/* // seems no need. coremeter is calculated earlier than postdamage
+		entity attacker = DamageInfo_GetAttacker( damageInfo )
+		if ( IsValid( attacker ) && attacker.IsTitan() )
+		{
+			float damageReduced = damage * file.bossTitanDamageReductionScale[ titan ]
+			// add reduced damage, player can still receive normal amount titancore meter
+			AddCreditToTitanCoreBuilderForTitanDamageInflicted( attacker, damageReduced )
+		}
+		*/
+	}
+}
+
+void function NPCTitanSpawned( entity titan )
+{
+	switch ( titan.ai.bossTitanType )
+	{
+		// remove for mp
+		//case TITAN_WEAK:
+		//case TITAN_HENCH:
+			//break
+
+		case TITAN_BOSS: // titan: generic boss
+			MpBossTitan_Register( titan )
+
+			// add damage reduction
+			//if ( titan.ai.bossTitanType == TITAN_BOSS ) // does this ever meaningful?
+			AddEntityCallback_OnDamaged( titan, OnBossTitanCoreMitigation )
+
+			// remove for mp
+			//if ( titan.HasKey( "skip_boss_intro" ) && titan.GetValueForKey( "skip_boss_intro" ) == "1" )
+			//	return
+			thread MpBossTitan_NoIntroSetup( titan ) // setup dialogue stuff
+			break
+
+		case TITAN_MERC: // titan: mercenary
+			// remove for mp, these should be decided by spawn function
+			// TODO: This SetSkin() call should move to MpBossTitan_Register() when the above TITAN_BOSS stuff is cleaned up/removed.
+			//titan.SetSkin( 1 ) // all titan models have a boss titan version of the skin at index 1
+
+			//print( "RUNNING MpBossTitan_Register()" )
+			MpBossTitan_Register( titan )
+			//ApplyTitanDamageState( titan ) // remove for mp
+
+			// add damage reduction
+			AddEntityCallback_OnDamaged( titan, OnBossTitanCoreMitigation )
+			AddEntityCallback_OnPostDamaged( titan, BossTitanDamageReduction )
+
+			// remove for mp
+			//if ( titan.HasKey( "skip_boss_intro" ) && titan.GetValueForKey( "skip_boss_intro" ) == "1" )
+			//	return
+
+			// remove for mp
+			//if ( !titan.ai.bossTitanPlayIntro )
+			//	return
+
+			//print( "RUNNING MpBossTitan_PlayBossTitanIntro()" )
+			thread MpBossTitan_PlayBossTitanIntro( titan )
+			break
+
+		// case TITAN_WEAK:
+			// MakeLowHealthTitan( titan )
+			// break
+
+		// nessie: comment out for mp
+		//case TITAN_AUTO:
+			//if ( !IsMultiplayer() && GetMapName() == "sp_hub_timeshift" || GetMapName() == "sp_timeshift_spoke02" )
+			//	MakeLowHealthTitan( titan )
+			//break
+		default:
+			return
+	}
+}
+
+// after fnished intro, add other dialogue callbacks
+void function OnBossTitanIntroFinished( entity bossTitan )
+{
+	AddEntityCallback_OnDamaged( bossTitan, OnBossTitanDamaged )
+	AddTitanCallback_OnHealthSegmentLost( bossTitan, OnBossTitanLostSegment )
+}
+
+void function OnBossTitanDamaged( entity titan, var damageInfo )
+{
+}
+
+void function OnBossTitanLostSegment( entity titan, entity attacker )
+{
+	if ( !titan.IsNPC() || !MpBossTitan_TitanVDUEnabled( titan ) )
+		return
+
+	if ( IsMercTitan( titan ) )
+		MpBossTitan_ConversationLostSegment( titan, GetTitanCurrentRegenTab( titan ) )
+}
+
+bool function IsVDUTitan( entity titan )
+{
+	//Assert( IsSingleplayer() )
+
+	//if ( titan.GetTeam() != TEAM_IMC )
+	//	return false
+
+	if ( !titan.IsNPC() )
+		return false
+
+	switch ( titan.ai.bossTitanType )
+	{
+		case TITAN_AUTO:
+		case TITAN_WEAK:
+			return false
+
+		case TITAN_HENCH:
+		case TITAN_MERC:
+		case TITAN_BOSS:
+			return true
+	}
+
+	Assert( 0, "Unknown boss titan type " + titan.ai.bossTitanType )
+	unreachable
+}
+
+bool function MpBossTitan_TitanIsBoss( entity titan )
+{
+	//Assert( IsSingleplayer() )
+
+	//if ( titan.GetTeam() != TEAM_IMC )
+	//	return false
+
+	switch ( titan.ai.bossTitanType )
+	{
+		case TITAN_MERC:
+		case TITAN_BOSS:
+			return true
+	}
+
+	return false
+}
+
+// from sh_ai_boss_titan.gnut
+asset function MpBossTitan_GetBossCharacterModel( entity titan )
+{
+	string character = titan.ai.bossCharacterName
+	return file.bossTitans[ character ].characterModel
+}
+
+string function GetBossNameFromID( int bossID )
+{
+	foreach ( name, data in file.bossTitans )
+	{
+		if ( data.bossID == bossID )
+			return name
+	}
+
+	return ""
+}
+
+void function OnTitanLostSegment( entity titan, entity attacker )
+{
+	entity player
+
+	if ( !titan.IsPlayer() )
+		player = titan.GetBossPlayer()
+	else
+		player = titan
+
+	if ( !IsValid( player ) )
+		return
+
+	if ( !IsValid( attacker ) )
+		return
+
+	if ( !attacker.IsNPC() || !IsVDUTitan( attacker ) || !MpBossTitan_TitanVDUEnabled( attacker ) )
+		return
+
+	MpBossTitan_ConversationTookPlayerSegment( player, GetSegmentHealthForTitan( titan ) )
+}
+
+void function BossTitanRetreat( entity titan )
+{
+	if ( !IsVDUTitan( titan ) || !MpBossTitan_TitanVDUEnabled( titan ) )
+		return
+
+	MpBossTitan_ConversationRetreat( titan )
+}
+
+void function BossTitanAdvance( entity titan )
+{
+	if ( !IsVDUTitan( titan ) || !MpBossTitan_TitanVDUEnabled( titan ) )
+		return
+
+	MpBossTitan_ConversationAdvance( titan )
+}
+
+void function OnTitanCoreUsed( entity titan, entity coreWeapon )
+{
+	if ( IsVDUTitan( titan ) && MpBossTitan_TitanVDUEnabled( titan ) )
+	{
+		entity enemy = titan.GetEnemy()
+		if ( IsValid( enemy ) && enemy.IsPlayer() )
+			MpBossTitan_ConversationUseCoreAbility( titan )
+	}
+	else if ( titan.IsPlayer() )
+		MpBossTitan_ConversationPlayerUseCoreAbility( titan )
+}
+
+//  _   _ _____ ___ _     ___ _______   __
+// | | | |_   _|_ _| |   |_ _|_   _\ \ / /
+// | | | | | |  | || |    | |  | |  \ V / 
+// | |_| | | |  | || |___ | |  | |   | |  
+//  \___/  |_| |___|_____|___| |_|   |_|  
+
+bool function IsMercTitan( entity titan )
+{
+	//if ( IsMultiplayer() )
+	//	return false
+	//if ( titan.GetTeam() != TEAM_IMC )
+	//	return false
+	return titan.ai.bossTitanType == TITAN_MERC
+}
+
+bool function MpBossTitan_TitanVDUEnabled( entity titan )
+{
+	return titan.ai.bossTitanVDUEnabled
+}
+
+entity function MpBossTitan_GetNearbyBossForPlayer( entity player )
+{
+	int team = player.GetTeam()
+	vector origin = player.GetOrigin()
+
+    array<entity> bossTitans
+    foreach ( entity titan in GetNPCArrayByClass( "npc_titan" ) )
+    {
+        if ( !IsAlive( titan ) )
+            continue
+        if ( team == titan.GetTeam() ) // same team titan
+            continue
+
+        if ( MpBossTitan_TitanIsBoss( titan ) )
+            bossTitans.append( titan )
+    }
+
+	entity bossTitan
+	if ( bossTitans.len() > 0 )
+		bossTitan = GetClosest( bossTitans, origin )
+
+	return bossTitan // may return a null
+}
+
+bool function MpBossTitan_IsGenericTitan( entity titan )
+{
+	string name = titan.ai.bossCharacterName
+
+	string generic = "Generic"
+	return ( name.len() >= generic.len() && name.slice( 0,generic.len() ) == "Generic" )
+}
+
+//  _____ ___ _____  _    _   _     ____  _____ _____ _____ ___ _   _  ____ ____  
+// |_   _|_ _|_   _|/ \  | \ | |   / ___|| ____|_   _|_   _|_ _| \ | |/ ___/ ___| 
+//   | |  | |  | | / _ \ |  \| |   \___ \|  _|   | |   | |  | ||  \| | |  _\___ \ 
+//   | |  | |  | |/ ___ \| |\  |    ___) | |___  | |   | |  | || |\  | |_| |___) |
+//   |_| |___| |_/_/   \_\_| \_|   |____/|_____| |_|   |_| |___|_| \_|\____|____/ 
+
+void function MpBossTitan_SetDamageScale( entity titan, float damage )
+{
+	if ( !( titan in file.bossTitanDamageScale ) ) // not registered
+		return
+
+	file.bossTitanDamageScale[ titan ] = damage
+}
+
+void function MpBossTitan_SetDamageReductionScale( entity titan, float damageReduction )
+{
+	if ( !( titan in file.bossTitanDamageReductionScale ) ) // not registered
+		return
+
+	file.bossTitanDamageReductionScale[ titan ] = damageReduction
+}
+
+//  ____  _____ ____ ___ ____ _____ _____ ____  ___ _   _  ____     _   _ _______        __    ____   ___  ____ ____  
+// |  _ \| ____/ ___|_ _/ ___|_   _| ____|  _ \|_ _| \ | |/ ___|   | \ | | ____\ \      / /   | __ ) / _ \/ ___/ ___| 
+// | |_) |  _|| |  _ | |\___ \ | | |  _| | |_) || ||  \| | |  _    |  \| |  _|  \ \ /\ / /    |  _ \| | | \___ \___ \ 
+// |  _ <| |__| |_| || | ___) || | | |___|  _ < | || |\  | |_| |   | |\  | |___  \ V  V /     | |_) | |_| |___) |__) |
+// |_| \_\_____\____|___|____/ |_| |_____|_| \_\___|_| \_|\____|   |_| \_|_____|  \_/\_/      |____/ \___/|____/____/ 
+
+void function MpBossTitan_Register( entity bossTitan )
+{
+	string name = bossTitan.ai.bossCharacterName == "" ? GetGenericPilotName() : bossTitan.ai.bossCharacterName
+	bossTitan.ai.bossCharacterName = name
+
+	// init in-file table
+	file.bossTitanDamageReductionScale[ bossTitan ] <- 0.0
+
+	// run callbacks
+	foreach ( void functionref( entity ) callbackFunc in file.bossTitanRegisterCallbacks )
+		callbackFunc( bossTitan )
+}
+
+const int NUM_VOICES = 8 // total of 8 voice packs for generic titans
+
+string function GetGenericPilotName()
+{
+	return "Generic" + RandomIntRange( 1, NUM_VOICES + 1 )
+}
+
+// should never use deregister. it's not implement good enough, can't handle most things like removing entity callbacks
+void function MpBossTitan_Deregister( entity bossTitan )
+{
+	bossTitan.Signal( "DeregisterBossTitan" )
+	bossTitan.ai.bossTitanType = TITAN_AUTO
+
+	// clean up in-file table
+	if ( bossTitan in file.bossTitanDamageReductionScale )
+		delete file.bossTitanDamageReductionScale[ bossTitan ]
+
+	// run callbacks
+	foreach ( void functionref( entity ) callbackFunc in file.bossTitanDeregisterCallbacks )
+		callbackFunc( bossTitan )
+}
+
+void function AddCallback_OnMpBossTitanRegister( void functionref( entity ) callbackFunc )
+{
+	if ( !file.bossTitanRegisterCallbacks.contains( callbackFunc ) )
+		file.bossTitanRegisterCallbacks.append( callbackFunc )
+}
+
+void function AddCallback_OnMpBosstitanDeregister( void functionref( entity ) callbackFunc )
+{
+	if ( !file.bossTitanDeregisterCallbacks.contains( callbackFunc ) )
+		file.bossTitanDeregisterCallbacks.append( callbackFunc )
+}
+#endif // MP

--- a/mod/scripts/vscripts/modai/extra_ai_spawner.gnut
+++ b/mod/scripts/vscripts/modai/extra_ai_spawner.gnut
@@ -37,6 +37,14 @@ global function ExtraSpawner_SpawnLegionWithBlisk
 global function ExtraSpawner_SpawnMonarchWithSarah
 global function ExtraSpawner_SpawnVanguardWithSarah
 
+// boss titan with intro
+global function ExtraSpawner_SpawnBossTitan_Ash
+global function ExtraSpawner_SpawnBossTitan_Viper
+global function ExtraSpawner_SpawnBossTitan_Richter
+global function ExtraSpawner_SpawnBossTitan_Slone
+global function ExtraSpawner_SpawnBossTitan_Kane
+global function ExtraSpawner_SpawnBossTitan_Blisk // seems unused and unfinished
+
 global function ExtraSpawner_SpawnCarePackageToGetWeapons
 // these settings should be done in prematch, don't do it right after levelLoad
 global function ExtraSpawner_SetCarePackageWeapons
@@ -182,8 +190,9 @@ void function ExtraAISpawner_Init()
 	//AddClientCommandCallback( "assassinpilot", CC_SpawnAssassinPilot )
 	//AddClientCommandCallback( "specialistgrunt", CC_SpawnSpecialistGrunt )
 	//AddClientCommandCallback( "pilot", CC_SpawnPilotElite )
+	AddClientCommandCallback( "boss_intro", CC_SpawnBossTitanWithIntro )
 }
-	
+
 void function OnStalkerSpawned( entity stalker )
 {	
 	int team = stalker.GetTeam()
@@ -812,6 +821,52 @@ bool function CC_SpawnPilotElite( entity player, array<string> args )
 	//pilot.GiveWeapon( "mp_weapon_defender" )
 	pilot.GiveWeapon( "mp_weapon_pulse_lmg" )
 	//pilot.GiveWeapon( "mp_weapon_hemlok" )
+	return true
+}
+
+bool function CC_SpawnBossTitanWithIntro( entity player, array<string> args )
+{
+	if ( !GetConVarBool( "sv_cheats" ) )
+	{
+		if( !BATTERY_SPAWNERS.contains( player.GetUID() ) )
+			return false
+	}
+
+	if ( args.len() == 0 )
+		return true
+
+	vector pos = GetPlayerCrosshairOrigin( player )
+	vector playerAngs = player.EyeAngles()
+	vector rot = < 0, ClampAngle( playerAngs.y - 180 ), 0 >
+	int team = TEAM_BOTH
+
+	string bossType = args[0].tolower()
+	switch ( bossType )
+	{
+		case "ash":
+			ExtraSpawner_SpawnBossTitan_Ash( pos, rot, team )
+			break
+		case "viper":
+			ExtraSpawner_SpawnBossTitan_Viper( pos, rot, team )
+			break
+		/*
+		// these intros can't be used in mp
+		case "richter":
+			ExtraSpawner_SpawnBossTitan_Richter( pos, rot, team )
+			break
+		case "slone":
+			ExtraSpawner_SpawnBossTitan_Slone( pos, rot, team )
+			break
+		case "kane":
+			ExtraSpawner_SpawnBossTitan_Kane( pos, rot, team )
+			break
+		// blisk intro seems unused and unfinished
+		case "blisk":
+			ExtraSpawner_SpawnBossTitan_Blisk( pos, rot, team )
+			break
+		*/
+	}
+
 	return true
 }
 
@@ -1465,7 +1520,7 @@ void function ExtraSpawner_SpawnTitanBT( vector pos, vector rot, int team, void 
 	SetSpawnOption_AISettings( titan, "npc_titan_buddy")
 	SetSpawnOption_Titanfall( titan )
 	SetSpawnOption_Warpfall( titan )
-	SetSpawnOption_NPCTitan( titan, TITAN_HENCH )
+	//SetSpawnOption_NPCTitan( titan, TITAN_HENCH ) // mp don't need boss titan setting
     titan.ai.titanSpawnLoadout.setFile = "titan_buddy"
     OverwriteLoadoutWithDefaultsForSetFile( titan.ai.titanSpawnLoadout )
 	file.npcSpawnFromExtraSpawner[ titan ] <- true
@@ -1475,7 +1530,7 @@ void function ExtraSpawner_SpawnTitanBT( vector pos, vector rot, int team, void 
 	titan.GetOffhandWeapon( OFFHAND_SPECIAL ).AddMod( "slow_recovery_vortex" ) // fix mod
 	titan.GetOffhandWeapon( OFFHAND_ORDNANCE ).AddMod( "upgradeCore_MissileRack_Vanguard" ) // fix mod: lock on heavy armor target only
 	titan.GetOffhandWeapon( OFFHAND_EQUIPMENT ).AddMod( "npc_bt_balance" ) // balance core ability
-	//titan.SetSkin(1)
+	//titan.SetSkin(1) // sarah skin
 	SetSquad( titan, squadName )
 
 	if ( titanHandler != null )
@@ -2868,4 +2923,372 @@ void function ExtraSpawner_ReaperHandler( entity reaper )
 
 		wait RandomFloatRange( 10.0, 20.0 )
 	}
+}
+
+// boss titan with intro
+entity function ExtraSpawner_SpawnBossTitan_Ash( vector pos, vector rot, int team )
+{
+	string setFile = "titan_stryder_leadwall"
+	string aiSet = "npc_titan_stryder_leadwall_bounty" // with a overlay
+	string executionRef = "execution_ronin_prime" // funny with MeleeSyncedNPC
+
+	entity titan = CreateNPC( "npc_titan", team, pos, rot )
+	SetSpawnOption_AISettings( titan, aiSet )
+	// setup boss
+	titan.ai.bossCharacterName = "Ash"
+	titan.ai.bossTitanType = TITAN_MERC // set to titan_merc before DispatchSpawn() will play a intro
+
+    titan.ai.titanSpawnLoadout.setFile = setFile
+    OverwriteLoadoutWithDefaultsForSetFile( titan.ai.titanSpawnLoadout )
+
+	// we'll do intro, hide on spawn
+	HideName( titan )
+	titan.Hide()
+	DispatchSpawn( titan )
+
+	titan.SetSkin( 6 ) // possibly be ash's skin?
+	titan.SetDecal( 10 ) // nose art
+	// titan won't have a soul until they DispatchSpawn()
+	entity titanSoul = titan.GetTitanSoul()
+	titanSoul.soul.titanLoadout.titanExecution = executionRef
+
+	// ash settings!
+	// can't use localized string as pilotTitle for they will eject and reset autotitan's title
+	ExtraSpawner_SetUpTitanSeatedPilot( titan, team, 1500, false, $"models/Humans/heroes/imc_hero_ash.mdl", "艾許" )
+
+	titan.SetTitle( "#BOSSNAME_ASH" )
+	// amped behavior
+	// health settings. 4x health, 75% damage reduction ≈ 16x health, without annoying health bar
+	titan.SetMaxHealth( titan.GetMaxHealth() * 4 )
+	titan.SetHealth( titan.GetMaxHealth() )
+	MpBossTitan_SetDamageScale( titan, 1.5 ) // they can deal higher damage
+	MpBossTitan_SetDamageReductionScale( titan, 0.75 )
+	MpBossTitan_SetTitanConversationStyle( titan, eBossTitanConvStyle.PLAY_TO_ALL ) // their conversation is played to all players
+	// attack settings
+	titan.kv.WeaponProficiency = eWeaponProficiency.PERFECT // they can shoot very nice
+	titan.SetCapabilityFlag( bits_CAP_SYNCED_MELEE_ATTACK, false ) // disable synced melee behavior, we use melee_synced_npc
+	// core ability
+	TitanHealth_SetTitanCoreBuilderMultiplier( titan, 5.0 ) // want them get core abilities faster
+	// behavior
+	titan.SetBehaviorSelector( "behavior_titan_shotgun" ) // become smarter, since pilot has control of it
+	// nuke
+	//NPC_SetNuclearPayload( titan ) // imc titans do nuke
+	//TitanEject_SetSoulUseNPCPilotAsNukeAttacker( titanSoul, true ) // modified function in sh_titan.gnut
+	SetupNPCPilotEmbarkedTitanNuke( titan )
+	// set up embarked behavior, we may feature npc pilot disembarking in future?
+	SetTitanSoulEmbarkedSettings( titan, "npc_titan_stryder_leadwall_bounty", "behavior_titan_shotgun", "#BOSSNAME_ASH" )
+
+	thread ExtraSpawner_TitanHandler( titan )
+
+	// show again after DispatchSpawn(), ShowName() is handled in intro
+	titan.Show()
+
+	return titan
+}
+
+entity function ExtraSpawner_SpawnBossTitan_Viper( vector pos, vector rot, int team )
+{
+	string setFile = "titan_stryder_sniper"
+	string aiSet = "npc_titan_stryder_sniper_bounty" // with a overlay
+	string executionRef = "execution_northstar_prime" // funny with MeleeSyncedNPC
+
+	entity titan = CreateNPC( "npc_titan", team, pos, rot )
+	SetSpawnOption_AISettings( titan, aiSet )
+	// setup boss
+	titan.ai.bossCharacterName = "Viper"
+	titan.ai.bossTitanType = TITAN_MERC // set to titan_merc before DispatchSpawn() will play a intro
+
+    titan.ai.titanSpawnLoadout.setFile = setFile
+    OverwriteLoadoutWithDefaultsForSetFile( titan.ai.titanSpawnLoadout )
+
+	// we'll do intro, hide on spawn
+	HideName( titan )
+	titan.Hide()
+	DispatchSpawn( titan )
+
+	titan.SetSkin( 1 ) // possibly be viper's skin?
+	titan.SetDecal( 10 ) // nose art
+	// titan won't have a soul until they DispatchSpawn()
+	entity titanSoul = titan.GetTitanSoul()
+	titanSoul.soul.titanLoadout.titanExecution = executionRef
+
+	// viper settings!
+	// can't use localized string as pilotTitle for they will eject and reset autotitan's title
+	// use mp pilot model: pulse blade male
+	ExtraSpawner_SetUpTitanSeatedPilot( titan, team, 1500, false, $"models/humans/pilots/pilot_medium_reaper_m.mdl", "毒蛇" )
+
+	titan.SetTitle( "#BOSSNAME_VIPER" )
+	// amped behavior
+	// health settings. 4x health, 75% damage reduction ≈ 16x health, without annoying health bar
+	titan.SetMaxHealth( titan.GetMaxHealth() * 4 )
+	titan.SetHealth( titan.GetMaxHealth() )
+	MpBossTitan_SetDamageScale( titan, 1.5 ) // they can deal higher damage
+	MpBossTitan_SetDamageReductionScale( titan, 0.75 )
+	MpBossTitan_SetTitanConversationStyle( titan, eBossTitanConvStyle.PLAY_TO_ALL ) // their conversation is played to all players
+	// attack settings
+	titan.kv.WeaponProficiency = eWeaponProficiency.PERFECT // they can shoot very nice
+	titan.SetCapabilityFlag( bits_CAP_SYNCED_MELEE_ATTACK, false ) // disable synced melee behavior, we use melee_synced_npc
+	// core ability
+	TitanHealth_SetTitanCoreBuilderMultiplier( titan, 5.0 ) // want them get core abilities faster
+	// behavior
+	titan.SetBehaviorSelector( "behavior_titan_sniper" ) // become smarter, since pilot has control of it
+	// nuke
+	//NPC_SetNuclearPayload( titan ) // imc titans do nuke
+	//TitanEject_SetSoulUseNPCPilotAsNukeAttacker( titanSoul, true ) // modified function in sh_titan.gnut
+	SetupNPCPilotEmbarkedTitanNuke( titan )
+	// set up embarked behavior, we may feature npc pilot disembarking in future?
+	SetTitanSoulEmbarkedSettings( titan, "npc_titan_stryder_sniper_bounty", "behavior_titan_sniper", "#BOSSNAME_VIPER" )
+
+	thread ExtraSpawner_TitanHandler( titan )
+
+	// show again after DispatchSpawn(), ShowName() is handled in intro
+	titan.Show()
+
+	return titan
+}
+
+
+
+// -------------------------------------------------------------------------- //
+// -------------------------- BELOW ARE UNFINISHED -------------------------- //
+// -------------------------------------------------------------------------- //
+
+entity function ExtraSpawner_SpawnBossTitan_Richter( vector pos, vector rot, int team )
+{
+	string setFile = "titan_atlas_tracker"
+	string aiSet = "npc_titan_atlas_tracker_bounty" // with a overlay
+	string executionRef = "execution_tone_prime" // funny with MeleeSyncedNPC
+
+	entity titan = CreateNPC( "npc_titan", team, pos, rot )
+	SetSpawnOption_AISettings( titan, aiSet )
+	// setup boss
+	titan.ai.bossCharacterName = "Richter"
+	titan.ai.bossTitanType = TITAN_MERC // set to titan_merc before DispatchSpawn() will play a intro
+
+    titan.ai.titanSpawnLoadout.setFile = setFile
+    OverwriteLoadoutWithDefaultsForSetFile( titan.ai.titanSpawnLoadout )
+
+	// we'll do intro, hide on spawn
+	HideName( titan )
+	titan.Hide()
+	DispatchSpawn( titan )
+
+	//titan.SetSkin( 8 ) // unknown
+	//titan.SetDecal( 12 ) // nose art
+	// titan won't have a soul until they DispatchSpawn()
+	entity titanSoul = titan.GetTitanSoul()
+	titanSoul.soul.titanLoadout.titanExecution = executionRef
+
+	// richter settings!
+	// can't use localized string as pilotTitle for they will eject and reset autotitan's title
+	// cloak model is not suitable for npc usage, temp replace with: grapple male
+	ExtraSpawner_SetUpTitanSeatedPilot( titan, team, 1500, false, $"models/humans/pilots/pilot_medium_geist_m.mdl", "裏赫特" )
+
+	titan.SetTitle( "#BOSSNAME_RICHTER" )
+	// amped behavior
+	// health settings. 4x health, 75% damage reduction ≈ 16x health, without annoying health bar
+	titan.SetMaxHealth( titan.GetMaxHealth() * 4 )
+	titan.SetHealth( titan.GetMaxHealth() )
+	MpBossTitan_SetDamageScale( titan, 1.5 ) // they can deal higher damage
+	MpBossTitan_SetDamageReductionScale( titan, 0.75 )
+	// attack settings
+	titan.kv.WeaponProficiency = eWeaponProficiency.PERFECT // they can shoot very nice
+	titan.SetCapabilityFlag( bits_CAP_SYNCED_MELEE_ATTACK, false ) // disable synced melee behavior, we use melee_synced_npc
+	// core ability
+	TitanHealth_SetTitanCoreBuilderMultiplier( titan, 5.0 ) // want them get core abilities faster
+	// behavior
+	titan.SetBehaviorSelector( "behavior_titan_long_range" ) // become smarter, since pilot has control of it
+	// nuke
+	//NPC_SetNuclearPayload( titan ) // imc titans do nuke
+	//TitanEject_SetSoulUseNPCPilotAsNukeAttacker( titanSoul, true ) // modified function in sh_titan.gnut
+	SetupNPCPilotEmbarkedTitanNuke( titan )
+	// set up embarked behavior, we may feature npc pilot disembarking in future?
+	SetTitanSoulEmbarkedSettings( titan, "npc_titan_atlas_tracker_bounty", "behavior_titan_long_range", "#BOSSNAME_RICHTER" )
+
+	thread ExtraSpawner_TitanHandler( titan )
+
+	// show again after DispatchSpawn(), ShowName() is handled in intro
+	titan.Show()
+
+	return titan
+}
+
+entity function ExtraSpawner_SpawnBossTitan_Slone( vector pos, vector rot, int team )
+{
+	string setFile = "titan_atlas_stickybomb"
+	string aiSet = "npc_titan_atlas_stickybomb_bounty" // with a overlay
+	string executionRef = "execution_ion" // funny with MeleeSyncedNPC. execution_ion_prime is bad for npc executions
+
+	entity titan = CreateNPC( "npc_titan", team, pos, rot )
+	SetSpawnOption_AISettings( titan, aiSet )
+	// setup boss
+	titan.ai.bossCharacterName = "Slone"
+	titan.ai.bossTitanType = TITAN_MERC // set to titan_merc before DispatchSpawn() will play a intro
+
+    titan.ai.titanSpawnLoadout.setFile = setFile
+    OverwriteLoadoutWithDefaultsForSetFile( titan.ai.titanSpawnLoadout )
+
+	// we'll do intro, hide on spawn
+	HideName( titan )
+	titan.Hide()
+	DispatchSpawn( titan )
+
+	//titan.SetSkin( 8 ) // unknown
+	//titan.SetDecal( 12 ) // nose art
+	// titan won't have a soul until they DispatchSpawn()
+	entity titanSoul = titan.GetTitanSoul()
+	titanSoul.soul.titanLoadout.titanExecution = executionRef
+
+	// slone settings!
+	// can't use localized string as pilotTitle for they will eject and reset autotitan's title
+	// temp replace model with: holopilot female
+	ExtraSpawner_SetUpTitanSeatedPilot( titan, team, 1500, false, $"models/humans/pilots/pilot_medium_stalker_f.mdl", "斯隆" )
+
+	titan.SetTitle( "#BOSSNAME_SLONE" )
+	// amped behavior
+	// health settings. 4x health, 75% damage reduction ≈ 16x health, without annoying health bar
+	titan.SetMaxHealth( titan.GetMaxHealth() * 4 )
+	titan.SetHealth( titan.GetMaxHealth() )
+	MpBossTitan_SetDamageScale( titan, 1.5 ) // they can deal higher damage
+	MpBossTitan_SetDamageReductionScale( titan, 0.75 )
+	// attack settings
+	titan.kv.WeaponProficiency = eWeaponProficiency.PERFECT // they can shoot very nice
+	titan.SetCapabilityFlag( bits_CAP_SYNCED_MELEE_ATTACK, false ) // disable synced melee behavior, we use melee_synced_npc
+	// core ability
+	TitanHealth_SetTitanCoreBuilderMultiplier( titan, 5.0 ) // want them get core abilities faster
+	// behavior
+	titan.SetBehaviorSelector( "behavior_titan" ) // become smarter, since pilot has control of it
+	// nuke
+	//NPC_SetNuclearPayload( titan ) // imc titans do nuke
+	//TitanEject_SetSoulUseNPCPilotAsNukeAttacker( titanSoul, true ) // modified function in sh_titan.gnut
+	SetupNPCPilotEmbarkedTitanNuke( titan )
+	// set up embarked behavior, we may feature npc pilot disembarking in future?
+	SetTitanSoulEmbarkedSettings( titan, "npc_titan_atlas_stickybomb_bounty", "behavior_titan", "#BOSSNAME_SLONE" )
+
+	thread ExtraSpawner_TitanHandler( titan )
+
+	// show again after DispatchSpawn(), ShowName() is handled in intro
+	titan.Show()
+
+	return titan
+}
+
+entity function ExtraSpawner_SpawnBossTitan_Kane( vector pos, vector rot, int team )
+{
+	string setFile = "titan_ogre_meteor"
+	string aiSet = "npc_titan_ogre_meteor_bounty" // with a overlay
+	string executionRef = "execution_scorch_prime" // funny with MeleeSyncedNPC
+
+	entity titan = CreateNPC( "npc_titan", team, pos, rot )
+	SetSpawnOption_AISettings( titan, aiSet )
+	// setup boss
+	titan.ai.bossCharacterName = "Kane"
+	titan.ai.bossTitanType = TITAN_MERC // set to titan_merc before DispatchSpawn() will play a intro
+
+    titan.ai.titanSpawnLoadout.setFile = setFile
+    OverwriteLoadoutWithDefaultsForSetFile( titan.ai.titanSpawnLoadout )
+
+	// we'll do intro, hide on spawn
+	HideName( titan )
+	titan.Hide()
+	DispatchSpawn( titan )
+
+	//titan.SetSkin( 8 ) // unknown
+	//titan.SetDecal( 12 ) // nose art
+	// titan won't have a soul until they DispatchSpawn()
+	entity titanSoul = titan.GetTitanSoul()
+	titanSoul.soul.titanLoadout.titanExecution = executionRef
+
+	// kane settings!
+	// can't use localized string as pilotTitle for they will eject and reset autotitan's title
+	// a-wall model is not suitable for npc usage. temp replace with: davis
+	ExtraSpawner_SetUpTitanSeatedPilot( titan, team, 1500, false, $"models/humans/pilots/sp_medium_stalker_m.mdl", "凱恩" )
+
+	titan.SetTitle( "#BOSSNAME_KANE" )
+	// amped behavior
+	// health settings. 4x health, 75% damage reduction ≈ 16x health, without annoying health bar
+	titan.SetMaxHealth( titan.GetMaxHealth() * 4 )
+	titan.SetHealth( titan.GetMaxHealth() )
+	MpBossTitan_SetDamageScale( titan, 1.5 ) // they can deal higher damage
+	MpBossTitan_SetDamageReductionScale( titan, 0.75 )
+	// attack settings
+	titan.kv.WeaponProficiency = eWeaponProficiency.PERFECT // they can shoot very nice
+	titan.SetCapabilityFlag( bits_CAP_SYNCED_MELEE_ATTACK, false ) // disable synced melee behavior, we use melee_synced_npc
+	// core ability
+	TitanHealth_SetTitanCoreBuilderMultiplier( titan, 5.0 ) // want them get core abilities faster
+	// behavior
+	titan.SetBehaviorSelector( "behavior_titan_ogre_meteor" ) // become smarter, since pilot has control of it
+	// nuke
+	//NPC_SetNuclearPayload( titan ) // imc titans do nuke
+	//TitanEject_SetSoulUseNPCPilotAsNukeAttacker( titanSoul, true ) // modified function in sh_titan.gnut
+	SetupNPCPilotEmbarkedTitanNuke( titan )
+	// set up embarked behavior, we may feature npc pilot disembarking in future?
+	SetTitanSoulEmbarkedSettings( titan, "npc_titan_ogre_meteor_bounty", "behavior_titan_ogre_meteor", "#BOSSNAME_KANE" )
+
+	thread ExtraSpawner_TitanHandler( titan )
+
+	// show again after DispatchSpawn(), ShowName() is handled in intro
+	titan.Show()
+
+	return titan
+}
+
+// blisk intro seems unused and unfinished
+entity function ExtraSpawner_SpawnBossTitan_Blisk( vector pos, vector rot, int team )
+{
+	string setFile = "titan_ogre_minigun"
+	string aiSet = "npc_titan_ogre_minigun_bounty" // with a overlay
+	string executionRef = "execution_legion_prime" // funny with MeleeSyncedNPC
+
+	entity titan = CreateNPC( "npc_titan", team, pos, rot )
+	SetSpawnOption_AISettings( titan, aiSet )
+	// setup boss
+	titan.ai.bossCharacterName = "Blisk"
+	titan.ai.bossTitanType = TITAN_MERC // set to titan_merc before DispatchSpawn() will play a intro
+
+    titan.ai.titanSpawnLoadout.setFile = setFile
+    OverwriteLoadoutWithDefaultsForSetFile( titan.ai.titanSpawnLoadout )
+
+	// we'll do intro, hide on spawn
+	HideName( titan )
+	titan.Hide()
+	DispatchSpawn( titan )
+
+	titan.SetSkin( 8 ) // possibly be blisk's skin?
+	titan.SetDecal( 12 ) // nose art
+	// titan won't have a soul until they DispatchSpawn()
+	entity titanSoul = titan.GetTitanSoul()
+	titanSoul.soul.titanLoadout.titanExecution = executionRef
+
+	// blisk settings!
+	// can't use localized string as pilotTitle for they will eject and reset autotitan's title
+	ExtraSpawner_SetUpTitanSeatedPilot( titan, team, 1500, false, $"models/Humans/heroes/imc_hero_blisk.mdl", "布里斯克" )
+
+	titan.SetTitle( "#BOSSNAME_BLISK" )
+	// amped behavior
+	// health settings. 4x health, 75% damage reduction ≈ 16x health, without annoying health bar
+	titan.SetMaxHealth( titan.GetMaxHealth() * 4 )
+	titan.SetHealth( titan.GetMaxHealth() )
+	MpBossTitan_SetDamageScale( titan, 1.5 ) // they can deal higher damage
+	MpBossTitan_SetDamageReductionScale( titan, 0.75 )
+	// attack settings
+	titan.kv.WeaponProficiency = eWeaponProficiency.PERFECT // they can shoot very nice
+	titan.SetCapabilityFlag( bits_CAP_SYNCED_MELEE_ATTACK, false ) // disable synced melee behavior, we use melee_synced_npc
+	// core ability
+	TitanHealth_SetTitanCoreBuilderMultiplier( titan, 5.0 ) // want them get core abilities faster
+	// behavior
+	titan.SetBehaviorSelector( "behavior_titan_ogre_minigun" ) // become smarter, since pilot has control of it
+	// nuke
+	//NPC_SetNuclearPayload( titan ) // imc titans do nuke
+	//TitanEject_SetSoulUseNPCPilotAsNukeAttacker( titanSoul, true ) // modified function in sh_titan.gnut
+	SetupNPCPilotEmbarkedTitanNuke( titan )
+	// set up embarked behavior, we may feature npc pilot disembarking in future?
+	SetTitanSoulEmbarkedSettings( titan, "npc_titan_ogre_minigun_bounty", "behavior_titan_ogre_minigun", "#BOSSNAME_BLISK" )
+
+	thread ExtraSpawner_TitanHandler( titan )
+
+	// show again after DispatchSpawn(), ShowName() is handled in intro
+	titan.Show()
+
+	return titan
 }

--- a/mod/scripts/vscripts/modifiers/gamemode_survival.gnut
+++ b/mod/scripts/vscripts/modifiers/gamemode_survival.gnut
@@ -91,7 +91,8 @@ void function Modded_Gamemode_Survival_Init()
 
     // Callbacks
 	AddPostDamageCallback( "player", OnSurvivalPlayerPostDamage )
-	SetUsedCoreCallback( OnSurvivalPlayerCoreUsed ) // to nerf monarch
+	//SetUsedCoreCallback( OnSurvivalPlayerCoreUsed ) // to nerf monarch
+	AddCallback_OnTitanCoreUsed( OnSurvivalPlayerCoreUsed ) // new utility in sh_titancore_utility.gnut
 
     AddCallback_PlayerClassChanged( OnPlayerClassChanged )
     AddCallback_OnClientConnected( OnClientConnected )

--- a/mod/scripts/vscripts/nessieutil/npc_freeze.gnut
+++ b/mod/scripts/vscripts/nessieutil/npc_freeze.gnut
@@ -1,0 +1,48 @@
+// make use of npc.Freeze() and npc.Unfreeze() with a safe way
+global function Nessie_NPC_Freeze_Init
+
+global function FreezeNPC
+global function UnfreezeNPC
+global function NPCIsFrozen
+
+struct
+{
+    table<entity, bool> npcFrozenTable
+} file
+
+void function Nessie_NPC_Freeze_Init()
+{
+
+}
+
+void function InitNPCFrozenTable( entity npc )
+{
+    if ( !( npc in file.npcFrozenTable ) )
+        file.npcFrozenTable[npc] <- false // default value
+}
+
+void function FreezeNPC( entity npc )
+{
+    InitNPCFrozenTable( npc )
+    if ( NPCIsFrozen( npc ) ) // anti-crash: freeze a frozen npc will crash
+        return
+
+    npc.Freeze()
+    file.npcFrozenTable[npc] = true
+}
+
+void function UnfreezeNPC( entity npc )
+{
+    InitNPCFrozenTable( npc )
+    if ( !NPCIsFrozen( npc ) ) // anti-crash: unfreeze an active npc will crash
+        return
+
+    npc.Unfreeze()
+    file.npcFrozenTable[npc] = false
+}
+
+bool function NPCIsFrozen( entity npc )
+{
+    InitNPCFrozenTable( npc )
+    return file.npcFrozenTable[npc]
+}

--- a/mod/scripts/vscripts/weapons/sh_titancore_utility.gnut
+++ b/mod/scripts/vscripts/weapons/sh_titancore_utility.gnut
@@ -38,7 +38,11 @@ const EMP_BLAST_EFFECT = $"P_titan_core_atlas_blast"
 const EMP_BLAST_CHARGE_EFFECT = $"P_titan_core_atlas_charge"
 
 #if SERVER
-	global function SetUsedCoreCallback
+	//global function SetUsedCoreCallback // why have to make this only supports one callback?
+	// using modified version
+	global function AddCallback_OnTitanCoreUsed
+	global function RemoveCallback_OnTitanCoreUsed
+	//
 	global function CreateDefaultChargeEffect
 	global function SetCoreEffect
 	global function CreateCoreEffect
@@ -54,7 +58,9 @@ const EMP_BLAST_CHARGE_EFFECT = $"P_titan_core_atlas_charge"
 #if SERVER
 struct
 {
-	void functionref( entity, entity ) usedCoreCallback
+	// why have to make this only supports one callback?
+	//void functionref( entity, entity ) usedCoreCallback
+	array< void functionref( entity, entity ) > titanCoreOnUseCallbacks
 } file
 #endif
 
@@ -80,10 +86,27 @@ function MpTitanabilityFusionCore_Init()
 }
 
 #if SERVER
+// why have to make this only supports one callback?
+/*
 void function SetUsedCoreCallback( void functionref( entity, entity ) func )
 {
 	file.usedCoreCallback = func
 }
+*/
+
+// using modified version
+void function AddCallback_OnTitanCoreUsed( void functionref( entity, entity ) callbackFunc )
+{
+	if ( !file.titanCoreOnUseCallbacks.contains( callbackFunc ) )
+		file.titanCoreOnUseCallbacks.append( callbackFunc )
+}
+
+void function RemoveCallback_OnTitanCoreUsed( void functionref( entity, entity ) callbackFunc )
+{
+	if ( file.titanCoreOnUseCallbacks.contains( callbackFunc ) )
+		file.titanCoreOnUseCallbacks.fastremovebyvalue( callbackFunc )
+}
+//
 
 void function TitanCore_OnDamage( entity ent, var damageInfo )
 {
@@ -297,8 +320,12 @@ bool function CoreBegin( entity player, entity titan, entity weapon )
 
 	SetCoreEffect( titan, CreateCoreEffect, EMP_BLAST_EFFECT )
 
-	if ( file.usedCoreCallback != null )
-		file.usedCoreCallback( titan, weapon )
+	// why have to make this only supports one callback?
+	//if ( file.usedCoreCallback != null )
+	//	file.usedCoreCallback( titan, weapon )
+	// using modified version
+	foreach ( void functionref( entity, entity ) callbackFunc in file.titanCoreOnUseCallbacks )
+		callbackFunc( titan, weapon )
 
 	return true
 }
@@ -359,7 +386,7 @@ bool function CoreChargeBegin( entity player, entity titan, entity weapon )
 
 #if CLIENT
 	thread CoreActivatedVO( player )
-#if HAS_BOSS_AI
+#if HAS_BOSS_AI // THIS IS HARDCODED AS FUCK
 	if ( titan.IsPlayer() )
 	{
 		BossTitanPlayerUsedCoreAbility( titan, GetTitanCurrentRegenTab( titan ) )
@@ -372,7 +399,7 @@ bool function CoreChargeBegin( entity player, entity titan, entity weapon )
 	soul.SetCoreChargeStartTime( Time() )
 	soul.SetCoreUseDuration( coreWaitTime )
 
-#if HAS_BOSS_AI
+#if HAS_BOSS_AI // THIS IS HARDCODED AS FUCK
 	if ( titan.IsNPC() && BossTitanVDUEnabled( titan ) )
 	{
 		entity p = titan.GetEnemy()

--- a/unused/modai/_boss_titan_conversation(struct, can't use).gnut
+++ b/unused/modai/_boss_titan_conversation(struct, can't use).gnut
@@ -1,0 +1,1384 @@
+// From campaign, make it a server-side version
+untyped
+global function MP_BossTitan_Conversation_Init
+
+global function MpBossTitan_SetTitanConversationStyle
+global function MpBossTitan_PlayConversationDefault // based on titan's conversation style
+global function MpBossTitan_PlayConversationToTarget // play conversation to current target(eBossTitanConvStyle.PLAY_TO_TARGET)
+global function MpBossTitan_PlayConversationToAll // play conversation to all players(eBossTitanConvStyle.PLAY_TO_ALL)
+// main utility
+global function MpBossTitan_TryPlayConversationToPlayer
+
+// random conversation
+global function MpBossTitan_StartTitanRandomLines
+global function MpBossTitan_StopTitanRandomLines
+
+// intro conversations
+global function MpBossTitan_ConversationPostIntro
+global function MpBossTitan_ConversationNoIntro
+
+// player damage boss conversations
+global function MpBossTitan_ConversationDamaged
+global function MpBossTitan_ConversationLostSegment
+global function MpBossTitan_ConversationDoomed
+global function MpBossTitan_ConversationDeath
+// boss ability react conversations
+global function MpBossTitan_SetTitanEnableCoreConversation
+global function MpBossTitan_ConversationUseCoreAbility
+global function MpBossTitan_ConversationRetreat
+global function MpBossTitan_ConversationAdvance
+
+// boss damage player conversations
+global function MpBossTitan_ConversationTookPlayerSegment
+// boss react player ability conversations
+global function MpBossTitan_ConversationPlayerUseCoreAbility
+
+const float BOSS_TITAN_LINE_TIMEOUT = 10.0
+
+// debug
+const bool BOSS_TITAN_LINE_DEBUG_PRINT = true
+
+global enum eBossTitanConvStyle
+{
+    PLAY_TO_TARGET, // default
+    PLAY_TO_ALL,
+    DISABLED
+}
+
+struct MpBossTitanLine
+{
+	int conversationStyle = eBossTitanConvStyle.PLAY_TO_TARGET
+	string lastPlayedSoundAlias = ""
+	bool enableCoreConversation = true
+}
+
+struct MpBossTitanLineReceiver // player struct
+{
+	string lastPlayedSoundAlias = ""
+	entity lastSpeakerTitan = null
+}
+
+// from sh_ai_boss_titan.gnut
+struct BossTitanConversation
+{
+	array<string> soundAliases
+	// shouldn't include for mp
+	//array<string> usedAliases
+	//int eventPriority
+	//string eventVisualStyle
+	//asset customVideo
+}
+
+struct
+{
+    table<entity, MpBossTitanLine> mpBossTitanConversation
+	table<entity, MpBossTitanLineReceiver> mpBossTitanLineReceiver // player struct
+
+    // from sh_ai_boss_titan.gnut, adding support per player
+    table< string, table<string, BossTitanConversation> > bossTitanConvData
+	table< entity, table<string, float> > aliasUsedTimesOnPlayer
+
+    // from cl_ai_boss_titan.gnut, adding support per player or per boss
+    table<entity, float> bossNextRandomLineTime
+	table< entity, float > lastSaidLineTimeOnPlayer // handling last said line
+    table< entity, table<string, float> > lastSaidLineTimesOnPlayer // handling multiple lines
+
+	// from struct, needs to move out to specific for player
+	table< entity, array<string> > usedAliasesOnPlayer
+} file
+
+void function MP_BossTitan_Conversation_Init()
+{
+	#if !BOSS_TITAN_LINE_DEBUG_PRINT // debug should always init
+		if ( IsLobby() )
+			return
+	#endif
+
+	// initialize data(needs modded rpak)
+	InitBossTitanConversationData()
+
+	// signals from sh_ai_boss_titan
+	RegisterSignal( "CancelBossConversation" )
+
+	RegisterSignal( "StopBossTitanRandomLines" )
+
+    AddCallback_OnClientConnected( OnClientConnected )
+
+	AddCallback_OnMpBossTitanRegister( OnBossTitanRegister )
+	AddCallback_OnMpBosstitanDeregister( OnBossTitanDeregister )
+}
+
+
+
+//  ___ _   _ ___ _____ ___    _    _     ___ __________     ____    _  _____  _    
+// |_ _| \ | |_ _|_   _|_ _|  / \  | |   |_ _|__  / ____|   |  _ \  / \|_   _|/ \   
+//  | ||  \| || |  | |  | |  / _ \ | |    | |  / /|  _|     | | | |/ _ \ | | / _ \  
+//  | || |\  || |  | |  | | / ___ \| |___ | | / /_| |___    | |_| / ___ \| |/ ___ \ 
+// |___|_| \_|___| |_| |___/_/   \_\_____|___/____|_____|   |____/_/   \_\_/_/   \_\
+
+// initialize data(needs modded rpak)
+void function InitBossTitanConversationData()
+{
+	// fill boss fields
+    // I can't handle datatable importing, let's just fill it by hand
+    /*
+	var dataTable = GetDataTable( $"datatable/titan_boss_lines.rpak" )
+	for ( int i = 0; i < GetDatatableRowCount( dataTable ); i++ )
+	{
+		string bossName	= GetDataTableString( dataTable, i, GetDataTableColumnByName( dataTable, "characterName" ) )
+		string eventName = GetDataTableString( dataTable, i, GetDataTableColumnByName( dataTable, "event" ) )
+
+		if (!( bossName in file.bossTitanConvData ) )
+			file.bossTitanConvData[ bossName ] <- {}
+
+		if (!( eventName in file.bossTitanConvData[ bossName ] ))
+		{
+			BossTitanConversation data
+			// shouldn't include for mp
+			// data.eventPriority = GetDataTableInt( dataTable, i, GetDataTableColumnByName( dataTable, "priority" ) )
+			// data.eventVisualStyle = GetDataTableString( dataTable, i, GetDataTableColumnByName( dataTable, "visualStyle" ) )
+			// if ( data.eventVisualStyle == "vdu_custom" )
+			// {
+			// 	data.customVideo = GetDataTableAsset( dataTable, i, GetDataTableColumnByName( dataTable, "customVideo" ) )
+			// 	PrecacheMaterial( data.customVideo )
+			// }
+
+			file.bossTitanConvData[ bossName ][ eventName ] <- data
+		}
+
+		string soundAlias = GetDataTableString( dataTable, i, GetDataTableColumnByName( dataTable, "audio" ) )
+		file.bossTitanConvData[ bossName ][ eventName ].soundAliases.append( soundAlias )
+	}
+	*/
+
+	// only one issue left: init data will make all dialogues belong to a single struct
+
+	table<string, BossTitanConversation> emptyTable
+	BossTitanConversation emptyData
+	BossTitanConversation currentData
+	///////////
+	/// Ash ///
+	///////////
+	file.bossTitanConvData[ "Ash" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_doomed" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_playerUsedCoreAbility" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_coreAbility" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_random" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_playerUsedCoreAbility_boss1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_tookPlayerSegment_boss1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_coreAbility_boss1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_random_boss1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_coreAbility_backup" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_retreat" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_advance" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_tookPlayerSegment_backup" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_playerUsedCoreAbility_backup" ] <- clone emptyData
+	file.bossTitanConvData[ "Ash" ][ "bossTitan_random_backup" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_post_intro" ]
+	#if BOSS_TITAN_LINE_DEBUG_PRINT
+		print( "currentData print: " + string( currentData ) )
+	#endif
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_02_01_imc_ash" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_2segmentsLeft" ]
+	#if BOSS_TITAN_LINE_DEBUG_PRINT
+		print( "currentData print: " + string( currentData ) )
+	#endif
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_03_01_imc_ash" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_1segmentLeft" ]
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_04_01_imc_ash" )
+	// doomed
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_doomed" ]
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_05_01_imc_ash" )
+	// death
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_death" ]
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM111_06_01_imc_ash" )
+	// playerUsedCoreAbility
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_playerUsedCoreAbility" ]
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_07_01_imc_ash" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_08_01_imc_ash" )
+	// coreAbility
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_coreAbility" ]
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_09_01_imc_ash" )
+	// random
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_random" ]
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_10_01_imc_ash" )
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_11_01_imc_ash" )
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_12_01_imc_ash" )
+	// playerUsedCoreAbility_boss1segmentLeft
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_playerUsedCoreAbility_boss1segmentLeft" ]
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_13_01_imc_ash" )
+	// tookPlayerSegment_boss1segmentLeft
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_tookPlayerSegment_boss1segmentLeft" ]
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_14_01_imc_ash" )
+	// coreAbility_boss1segmentLeft
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_coreAbility_boss1segmentLeft" ]
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_15_01_imc_ash" )
+	// random_boss1segmentLeft
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_random_boss1segmentLeft" ]
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_16_01_imc_ash" )
+	// coreAbility_backup
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_coreAbility_backup" ]
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_17_01_imc_ash" )
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_18_01_imc_ash" )
+	// retreat
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_retreat" ]
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_19_01_imc_ash" )
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_20_01_imc_ash" )
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_21_01_imc_ash" )
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_22_01_imc_ash" )
+	// advance
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_advance" ]
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_23_01_imc_ash" )
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_24_01_imc_ash" )
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_25_01_imc_ash" )
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_26_01_imc_ash" )
+	// tookPlayerSegment_backup
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_tookPlayerSegment_backup" ]
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_27_01_imc_ash" )
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_28_01_imc_ash" )
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_29_01_imc_ash" )
+	// playerUsedCoreAbility_backup
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_playerUsedCoreAbility_backup" ]
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_30_01_imc_ash" )
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_31_01_imc_ash" )
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_32_01_imc_ash" )
+	// random_backup
+	currentData = file.bossTitanConvData[ "Ash" ][ "bossTitan_random_backup" ]
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_33_01_imc_ash" )
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_34_01_imc_ash" )
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_35_01_imc_ash" )
+	currentData.soundAliases.append( "diag_sp_BossVdu_BM112_36_01_imc_ash" )
+
+	/////////////
+	/// Viper ///
+	/////////////
+	file.bossTitanConvData[ "Viper" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_doomed" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_playerUsedCoreAbility" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_coreAbility" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_random" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_playerUsedCoreAbility_boss1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_tookPlayerSegment_boss1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_coreAbility_boss1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_random_boss1segmentLeft" ] <- clone emptyData
+	// viper don't have coreAbility_backup
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_retreat" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_advance" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_tookPlayerSegment_backup" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_playerUsedCoreAbility_backup" ] <- clone emptyData
+	file.bossTitanConvData[ "Viper" ][ "bossTitan_random_backup" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_post_intro" ]
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_03_01_imc_viper" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_2segmentsLeft" ]
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_04_01_imc_viper" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_1segmentLeft" ]
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_05_01_imc_viper" )
+	// doomed
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_doomed" ]
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_42_01_imc_viper" )
+	// death
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_death" ]
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_43_01_imc_viper" )
+	// playerUsedCoreAbility
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_playerUsedCoreAbility" ]
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_06_01_imc_viper" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_07_01_imc_viper" )
+	// coreAbility
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_coreAbility" ]
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_08_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_39_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_15_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_09_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_11_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_40_01_imc_viper" )
+	// random
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_random" ]
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_10_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_19_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_10_01_imc_viper" )
+	// playerUsedCoreAbility_boss1segmentLeft
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_playerUsedCoreAbility_boss1segmentLeft" ]
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_12_01_imc_viper" )
+	// tookPlayerSegment_boss1segmentLeft
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_tookPlayerSegment_boss1segmentLeft" ]
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_13_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_14_01_imc_viper" )
+	// coreAbility_boss1segmentLeft
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_coreAbility_boss1segmentLeft" ]
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_09_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_11_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_40_01_imc_viper" )
+	// random_boss1segmentLeft
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_random_boss1segmentLeft" ]
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_16_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_17_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_18_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_19_01_imc_viper" )
+	// viper don't have coreAbility_backup
+	// retreat
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_retreat" ]
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_20_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_21_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_22_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_23_01_imc_viper" )
+	// advance
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_advance" ]
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_24_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_25_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_26_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_27_01_imc_viper" )
+	// tookPlayerSegment_backup
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_tookPlayerSegment_backup" ]
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_28_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_32_01_imc_viper" )
+	// playerUsedCoreAbility_backup
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_playerUsedCoreAbility_backup" ]
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_29_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_30_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_31_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_36_01_imc_viper" )
+	// random_backup
+	currentData = file.bossTitanConvData[ "Viper" ][ "bossTitan_random_backup" ]
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_33_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_41_01_imc_viper" )
+	currentData.soundAliases.append( "diag_sp_bossFight_STS676_35_01_imc_viper" )
+
+	////////////////
+	/// Generic1 ///
+	////////////////
+	file.bossTitanConvData[ "Generic1" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_6segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_5segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_4segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_3segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_post_intro" ]
+	currentData.soundAliases.append( "diag_imc_pilot1_hc_battleStart" )
+	// 6segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_6segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot1_hc_lostChicket56" )
+	// 5segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_5segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot1_hc_lostChicket56" )
+	// 4segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_4segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot1_hc_lostChicket34" )
+	// 3segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_3segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot1_hc_lostChicket34" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_2segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot1_hc_lostChicket2" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_1segmentLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot1_hc_lostChicket1" )
+	// death
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_death" ]
+	currentData.soundAliases.append( "diag_imc_pilot1_hc_death" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.soundAliases.append( "diag_imc_pilot1_hc_plyrLostChicklet" )
+	// coreAbility_mp_titancore_shift_core
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot1_hc_coreSwordActivate" )
+	// coreAbility_mp_titancore_flight_core
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot1_hc_coreFlightActivate" )
+	// coreAbility_mp_titancore_laser_cannon
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ]
+	currentData.soundAliases.append( "diag_imc_pilot1_hc_coreLaserActivate" )
+	// coreAbility_mp_titancore_flame_wave
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ]
+	currentData.soundAliases.append( "diag_imc_pilot1_hc_coreFlameActivate" )
+	// coreAbility_mp_titancore_siege_mode
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ]
+	currentData.soundAliases.append( "diag_imc_pilot1_hc_coreSmartActivate" )
+	// coreAbility_mp_titancore_salvo_core
+	currentData = file.bossTitanConvData[ "Generic1" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot1_hc_coreRocketActivate" )
+
+	////////////////
+	/// Generic2 ///
+	////////////////
+	file.bossTitanConvData[ "Generic2" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_6segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_5segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_4segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_3segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_post_intro" ]
+	currentData.soundAliases.append( "diag_imc_pilot2_hc_battleStart" )
+	// 6segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_6segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot2_hc_lostChicket56" )
+	// 5segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_5segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot2_hc_lostChicket56" )
+	// 4segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_4segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot2_hc_lostChicket34" )
+	// 3segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_3segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot2_hc_lostChicket34" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_2segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot2_hc_lostChicket2" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_1segmentLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot2_hc_lostChicket1" )
+	// death
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_death" ]
+	currentData.soundAliases.append( "diag_imc_pilot2_hc_death" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.soundAliases.append( "diag_imc_pilot2_hc_plyrLostChicklet" )
+	// coreAbility_mp_titancore_shift_core
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot2_hc_coreSwordActivate" )
+	// coreAbility_mp_titancore_flight_core
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot2_hc_coreFlightActivate" )
+	// coreAbility_mp_titancore_laser_cannon
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ]
+	currentData.soundAliases.append( "diag_imc_pilot2_hc_coreLaserActivate" )
+	// coreAbility_mp_titancore_flame_wave
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ]
+	currentData.soundAliases.append( "diag_imc_pilot2_hc_coreFlameActivate" )
+	// coreAbility_mp_titancore_siege_mode
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ]
+	currentData.soundAliases.append( "diag_imc_pilot2_hc_coreSmartActivate" )
+	// coreAbility_mp_titancore_salvo_core
+	currentData = file.bossTitanConvData[ "Generic2" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot2_hc_coreRocketActivate" )
+
+	////////////////
+	/// Generic3 ///
+	////////////////
+	file.bossTitanConvData[ "Generic3" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_6segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_5segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_4segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_3segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_post_intro" ]
+	currentData.soundAliases.append( "diag_imc_pilot3_hc_battleStart" )
+	// 6segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_6segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot3_hc_lostChicket56" )
+	// 5segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_5segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot3_hc_lostChicket56" )
+	// 4segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_4segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot3_hc_lostChicket34" )
+	// 3segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_3segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot3_hc_lostChicket34" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_2segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot3_hc_lostChicket2" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_1segmentLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot3_hc_lostChicket1" )
+	// death
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_death" ]
+	currentData.soundAliases.append( "diag_imc_pilot3_hc_death" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.soundAliases.append( "diag_imc_pilot3_hc_plyrLostChicklet" )
+	// coreAbility_mp_titancore_shift_core
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot3_hc_coreSwordActivate" )
+	// coreAbility_mp_titancore_flight_core
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot3_hc_coreFlightActivate" )
+	// coreAbility_mp_titancore_laser_cannon
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ]
+	currentData.soundAliases.append( "diag_imc_pilot3_hc_coreLaserActivate" )
+	// coreAbility_mp_titancore_flame_wave
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ]
+	currentData.soundAliases.append( "diag_imc_pilot3_hc_coreFlameActivate" )
+	// coreAbility_mp_titancore_siege_mode
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ]
+	currentData.soundAliases.append( "diag_imc_pilot3_hc_coreSmartActivate" )
+	// coreAbility_mp_titancore_salvo_core
+	currentData = file.bossTitanConvData[ "Generic3" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot3_hc_coreRocketActivate" )
+
+	////////////////
+	/// Generic4 ///
+	////////////////
+	file.bossTitanConvData[ "Generic4" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_6segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_5segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_4segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_3segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_post_intro" ]
+	currentData.soundAliases.append( "diag_imc_pilot4_hc_battleStart" )
+	// 6segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_6segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot4_hc_lostChicket56" )
+	// 5segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_5segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot4_hc_lostChicket56" )
+	// 4segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_4segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot4_hc_lostChicket34" )
+	// 3segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_3segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot4_hc_lostChicket34" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_2segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot4_hc_lostChicket2" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_1segmentLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot4_hc_lostChicket1" )
+	// death
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_death" ]
+	currentData.soundAliases.append( "diag_imc_pilot4_hc_death" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.soundAliases.append( "diag_imc_pilot4_hc_plyrLostChicklet" )
+	// coreAbility_mp_titancore_shift_core
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot4_hc_coreSwordActivate" )
+	// coreAbility_mp_titancore_flight_core
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot4_hc_coreFlightActivate" )
+	// coreAbility_mp_titancore_laser_cannon
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ]
+	currentData.soundAliases.append( "diag_imc_pilot4_hc_coreLaserActivate" )
+	// coreAbility_mp_titancore_flame_wave
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ]
+	currentData.soundAliases.append( "diag_imc_pilot4_hc_coreFlameActivate" )
+	// coreAbility_mp_titancore_siege_mode
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ]
+	currentData.soundAliases.append( "diag_imc_pilot4_hc_coreSmartActivate" )
+	// coreAbility_mp_titancore_salvo_core
+	currentData = file.bossTitanConvData[ "Generic4" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot4_hc_coreRocketActivate" )
+
+	////////////////
+	/// Generic5 ///
+	////////////////
+	file.bossTitanConvData[ "Generic5" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_6segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_5segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_4segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_3segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_post_intro" ]
+	currentData.soundAliases.append( "diag_imc_pilot5_hc_battleStart" )
+	// 6segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_6segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot5_hc_lostChicket56" )
+	// 5segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_5segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot5_hc_lostChicket56" )
+	// 4segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_4segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot5_hc_lostChicket34" )
+	// 3segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_3segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot5_hc_lostChicket34" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_2segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot5_hc_lostChicket2" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_1segmentLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot5_hc_lostChicket1" )
+	// death
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_death" ]
+	currentData.soundAliases.append( "diag_imc_pilot5_hc_death" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.soundAliases.append( "diag_imc_pilot5_hc_plyrLostChicklet" )
+	// coreAbility_mp_titancore_shift_core
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot5_hc_coreSwordActivate" )
+	// coreAbility_mp_titancore_flight_core
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot5_hc_coreFlightActivate" )
+	// coreAbility_mp_titancore_laser_cannon
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ]
+	currentData.soundAliases.append( "diag_imc_pilot5_hc_coreLaserActivate" )
+	// coreAbility_mp_titancore_flame_wave
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ]
+	currentData.soundAliases.append( "diag_imc_pilot5_hc_coreFlameActivate" )
+	// coreAbility_mp_titancore_siege_mode
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ]
+	currentData.soundAliases.append( "diag_imc_pilot5_hc_coreSmartActivate" )
+	// coreAbility_mp_titancore_salvo_core
+	currentData = file.bossTitanConvData[ "Generic5" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot5_hc_coreRocketActivate" )
+
+	////////////////
+	/// Generic6 ///
+	////////////////
+	file.bossTitanConvData[ "Generic6" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_6segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_5segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_4segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_3segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_post_intro" ]
+	currentData.soundAliases.append( "diag_imc_pilot6_hc_battleStart" )
+	// 6segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_6segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot6_hc_lostChicket56" )
+	// 5segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_5segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot6_hc_lostChicket56" )
+	// 4segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_4segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot6_hc_lostChicket34" )
+	// 3segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_3segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot6_hc_lostChicket34" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_2segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot6_hc_lostChicket2" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_1segmentLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot6_hc_lostChicket1" )
+	// death
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_death" ]
+	currentData.soundAliases.append( "diag_imc_pilot6_hc_death" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.soundAliases.append( "diag_imc_pilot6_hc_plyrLostChicklet" )
+	// coreAbility_mp_titancore_shift_core
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot6_hc_coreSwordActivate" )
+	// coreAbility_mp_titancore_flight_core
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot6_hc_coreFlightActivate" )
+	// coreAbility_mp_titancore_laser_cannon
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ]
+	currentData.soundAliases.append( "diag_imc_pilot6_hc_coreLaserActivate" )
+	// coreAbility_mp_titancore_flame_wave
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ]
+	currentData.soundAliases.append( "diag_imc_pilot6_hc_coreFlameActivate" )
+	// coreAbility_mp_titancore_siege_mode
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ]
+	currentData.soundAliases.append( "diag_imc_pilot6_hc_coreSmartActivate" )
+	// coreAbility_mp_titancore_salvo_core
+	currentData = file.bossTitanConvData[ "Generic6" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot6_hc_coreRocketActivate" )
+
+	////////////////
+	/// Generic7 ///
+	////////////////
+	file.bossTitanConvData[ "Generic7" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_6segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_5segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_4segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_3segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_post_intro" ]
+	currentData.soundAliases.append( "diag_imc_pilot7_hc_battleStart" )
+	// 6segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_6segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot7_hc_lostChicket56" )
+	// 5segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_5segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot7_hc_lostChicket56" )
+	// 4segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_4segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot7_hc_lostChicket34" )
+	// 3segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_3segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot7_hc_lostChicket34" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_2segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot7_hc_lostChicket2" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_1segmentLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot7_hc_lostChicket1" )
+	// death
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_death" ]
+	currentData.soundAliases.append( "diag_imc_pilot7_hc_death" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.soundAliases.append( "diag_imc_pilot7_hc_plyrLostChicklet" )
+	// coreAbility_mp_titancore_shift_core
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot7_hc_coreSwordActivate" )
+	// coreAbility_mp_titancore_flight_core
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot7_hc_coreFlightActivate" )
+	// coreAbility_mp_titancore_laser_cannon
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ]
+	currentData.soundAliases.append( "diag_imc_pilot7_hc_coreLaserActivate" )
+	// coreAbility_mp_titancore_flame_wave
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ]
+	currentData.soundAliases.append( "diag_imc_pilot7_hc_coreFlameActivate" )
+	// coreAbility_mp_titancore_siege_mode
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ]
+	currentData.soundAliases.append( "diag_imc_pilot7_hc_coreSmartActivate" )
+	// coreAbility_mp_titancore_salvo_core
+	currentData = file.bossTitanConvData[ "Generic7" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot7_hc_coreRocketActivate" )
+
+	////////////////
+	/// Generic8 ///
+	////////////////
+	file.bossTitanConvData[ "Generic8" ] <- clone emptyTable
+	// init data
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_post_intro" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_6segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_5segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_4segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_3segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_2segmentsLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_1segmentLeft" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_death" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_tookPlayerSegment" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ] <- clone emptyData
+	file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ] <- clone emptyData
+	// append alias
+	// post_intro
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_post_intro" ]
+	currentData.soundAliases.append( "diag_imc_pilot8_hc_battleStart" )
+	// 6segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_6segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot8_hc_lostChicket56" )
+	// 5segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_5segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot8_hc_lostChicket56" )
+	// 4segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_4segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot8_hc_lostChicket34" )
+	// 3segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_3segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot8_hc_lostChicket34" )
+	// 2segmentsLeft
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_2segmentsLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot8_hc_lostChicket2" )
+	// 1segmentLeft
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_1segmentLeft" ]
+	currentData.soundAliases.append( "diag_imc_pilot8_hc_lostChicket1" )
+	// death
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_death" ]
+	currentData.soundAliases.append( "diag_imc_pilot8_hc_death" )
+	// tookPlayerSegment
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_tookPlayerSegment" ]
+	currentData.soundAliases.append( "diag_imc_pilot8_hc_plyrLostChicklet" )
+	// coreAbility_mp_titancore_shift_core
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_shift_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot8_hc_coreSwordActivate" )
+	// coreAbility_mp_titancore_flight_core
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_flight_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot8_hc_coreFlightActivate" )
+	// coreAbility_mp_titancore_laser_cannon
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_laser_cannon" ]
+	currentData.soundAliases.append( "diag_imc_pilot8_hc_coreLaserActivate" )
+	// coreAbility_mp_titancore_flame_wave
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_flame_wave" ]
+	currentData.soundAliases.append( "diag_imc_pilot8_hc_coreFlameActivate" )
+	// coreAbility_mp_titancore_siege_mode
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_siege_mode" ]
+	currentData.soundAliases.append( "diag_imc_pilot8_hc_coreSmartActivate" )
+	// coreAbility_mp_titancore_salvo_core
+	currentData = file.bossTitanConvData[ "Generic8" ][ "bossTitan_coreAbility_mp_titancore_salvo_core" ]
+	currentData.soundAliases.append( "diag_imc_pilot8_hc_coreRocketActivate" )
+
+	#if BOSS_TITAN_LINE_DEBUG_PRINT
+		print( "===================================================================" )
+		print( "Boss titan conversation init done!" )
+		print( "Initialized conversations: " )
+		foreach ( string bossName, table< string, BossTitanConversation > convTable in file.bossTitanConvData )
+		{
+			foreach ( string convType, BossTitanConversation convStruct in convTable )
+			{
+				print( "--------------------------------------------------------" )
+				print( "Struct print: " + string( convStruct ) )
+				print( "Boss name: " + bossName )
+				print( "Type: " + convType )
+				//print( "Sound Aliases: " )
+				//foreach ( string alias in convStruct.soundAliases )
+				//	print( "    " + alias )
+				print( "--------------------------------------------------------" )
+			}
+		}
+		print( "===================================================================" )
+	#endif // BOSS_TITAN_LINE_DEBUG_PRINT
+}
+
+// init player table
+void function OnClientConnected( entity player )
+{
+	MpBossTitanLineReceiver emptyStruct
+	file.mpBossTitanLineReceiver[ player ] <- emptyStruct
+	file.aliasUsedTimesOnPlayer[ player ] <- {}
+	file.lastSaidLineTimeOnPlayer[ player ] <- 0.0
+	file.lastSaidLineTimesOnPlayer[ player ] <- {}
+	file.usedAliasesOnPlayer[ player ] <- []
+}
+
+// init table for boss
+void function OnBossTitanRegister( entity titan )
+{
+	//print( "Calling OnBossTitanRegister() callback! in _boss_titan_conversation.gnut" )
+	MpBossTitanLine emptyStruct
+	file.mpBossTitanConversation[ titan ] <- emptyStruct
+	file.bossNextRandomLineTime[ titan ] <- 0.0
+}
+
+void function OnBossTitanDeregister( entity titan )
+{
+	if ( titan in file.mpBossTitanConversation )
+		delete file.mpBossTitanConversation[ titan ]
+	if ( titan in file.bossNextRandomLineTime )
+		delete file.bossNextRandomLineTime[ titan ]
+}
+
+void function MpBossTitan_ConversationAdvance( entity bossTitan )
+{
+	if ( !MpBossTitan_TitanIsBoss( bossTitan ) )
+		return
+
+	MpBossTitan_PlayConversationDefault( bossTitan, "bossTitan_advance" )
+}
+
+void function MpBossTitan_ConversationRetreat( entity bossTitan )
+{
+	if ( !MpBossTitan_TitanIsBoss( bossTitan ) )
+		return
+
+	MpBossTitan_PlayConversationDefault( bossTitan, "bossTitan_retreat" )
+}
+
+void function MpBossTitan_ConversationPlayerUseCoreAbility( entity player )
+{
+	entity titan = MpBossTitan_GetNearbyBossForPlayer( player )
+	if ( titan == null )
+		return
+
+	string conv = "bossTitan_playerUsedCoreAbility"
+
+	MpBossTitan_PlayConversationDefault( titan, conv )
+}
+
+void function MpBossTitan_SetTitanEnableCoreConversation( entity titan, bool enable )
+{
+	if ( !( titan in file.mpBossTitanConversation ) ) // this is not a registered boss?
+		return
+
+	file.mpBossTitanConversation[titan].enableCoreConversation = enable
+}
+
+void function MpBossTitan_ConversationUseCoreAbility( entity bossTitan )
+{
+	if ( !MpBossTitan_TitanIsBoss( bossTitan ) )
+		return
+	// modified setting, we can disable core dialogue for specific titan
+	if ( !( bossTitan in file.mpBossTitanConversation ) ) // this is not a registered boss?
+		return
+	if ( !file.mpBossTitanConversation[bossTitan].enableCoreConversation )
+		return
+
+	string conv = "bossTitan_coreAbility"
+
+	if ( MpBossTitan_IsGenericTitan( bossTitan ) )
+	{
+		entity coreWeapon = bossTitan.GetOffhandWeapon( OFFHAND_EQUIPMENT )
+		if ( !IsValid( coreWeapon ) )
+			return
+		string coreName = coreWeapon.GetWeaponClassName()
+		conv = conv + "_" + coreName
+	}
+
+	MpBossTitan_PlayConversationDefault( bossTitan, conv, "", true )
+}
+
+void function MpBossTitan_ConversationDeath( entity bossTitan, string bossName )
+{
+	if ( !MpBossTitan_TitanIsBoss( bossTitan ) )
+		return
+
+	MpBossTitan_CancelBossConversation( bossTitan )
+	MpBossTitan_PlayConversationDefault( bossTitan, "bossTitan_death", bossName, true )
+}
+
+void function MpBossTitan_ConversationDoomed( entity bossTitan )
+{
+	if ( !MpBossTitan_TitanIsBoss( bossTitan ) )
+		return
+
+	MpBossTitan_PlayConversationDefault( bossTitan, "bossTitan_doomed", "", true )
+}
+
+// this is unused
+void function MpBossTitan_ConversationDamaged( entity bossTitan )
+{
+	if ( !MpBossTitan_TitanIsBoss( bossTitan ) )
+		return
+
+	float amplitude = RandomFloatRange( 1.5, 2.5 )
+	float frequency = 20.0
+	float duration = RandomFloatRange( 0.2, 0.4 )
+
+	MpBossTitan_PlayConversationDefault( bossTitan, "bossTitan_damage" )
+}
+
+void function MpBossTitan_ConversationTookPlayerSegment( entity victimPlayer, int currentSegment )
+{
+	entity titan = MpBossTitan_GetNearbyBossForPlayer( victimPlayer )
+	if ( titan == null )
+		return
+
+	string conv = "bossTitan_tookPlayerSegment"
+
+	MpBossTitan_PlayConversationDefault( titan, conv )
+}
+
+void function MpBossTitan_ConversationLostSegment( entity bossTitan, int currentSegment )
+{
+	float amplitude = 2.0
+	float frequency = 40.0
+	float duration = RandomFloatRange( 1.5, 2.0 )
+
+	if ( !MpBossTitan_TitanIsBoss( bossTitan ) )
+		return
+
+	if ( GetDoomedState( bossTitan ) )
+		return
+
+	string conv = ""
+
+	if ( MpBossTitan_IsGenericTitan( bossTitan ) )
+	{
+		int tabs = GetTitanCurrentRegenTab( bossTitan )
+		if ( tabs == 1 )
+			conv = "bossTitan_1segmentLeft"
+		else
+			conv = "bossTitan_" + tabs + "segmentsLeft"
+	}
+	else
+	{
+		if ( GetHealthFrac( bossTitan ) <= 0.3 )
+			conv = "bossTitan_1segmentLeft"
+		else if ( GetHealthFrac( bossTitan ) <= 0.6 )
+			conv = "bossTitan_2segmentsLeft"
+	}
+
+	if ( conv == "" )
+		return
+
+	if ( bossTitan.ContextAction_IsMeleeExecution() )
+		return
+
+	if ( !IsAlive( bossTitan ) )
+		return
+
+	MpBossTitan_PlayConversationDefault( bossTitan, conv )
+}
+
+function MpBossTitan_ConversationNoIntro( entity bossTitan )
+{
+	if ( !MpBossTitan_TitanIsBoss( bossTitan ) )
+		return
+
+	if ( IsAlive( bossTitan ) )
+		MpBossTitan_PlayConversationDefault( bossTitan, "bossTitan_post_intro" )
+
+	// intro ended, start random line
+	MpBossTitan_StartTitanRandomLines( bossTitan )
+}
+
+void function MpBossTitan_ConversationPostIntro( entity bossTitan, bool VDUEnabled )
+{
+	if ( !MpBossTitan_TitanIsBoss( bossTitan ) )
+		return
+
+	if ( VDUEnabled )
+		MpBossTitan_PlayConversationDefault( bossTitan, "bossTitan_post_intro", "", true )
+
+	// intro ended, start random line
+	thread MpBossTitan_StartTitanRandomLines( bossTitan )
+}
+
+void function MpBossTitan_StartTitanRandomLines( entity titan )
+{
+	titan.EndSignal( "OnDeath" )
+	titan.EndSignal( "Doomed" )
+	titan.EndSignal( "DeregisterBossTitan" ) // deregistering a boss titan will stop it's conversation
+	// custom signal
+	titan.Signal( "StopBossTitanRandomLines" )
+	titan.EndSignal( "StopBossTitanRandomLines" )
+
+	DelayNextBossRandomLine( titan ) // initial wait
+
+	while ( IsValid( titan ) )
+	{
+		if ( file.bossNextRandomLineTime[ titan ] < Time() && IsAlive( titan.GetEnemy() ) )
+			MpBossTitan_PlayConversationDefault( titan, "bossTitan_random" )
+
+		wait 0.5
+	}
+}
+
+void function DelayNextBossRandomLine( entity titan )
+{
+	if ( !( titan in file.bossNextRandomLineTime ) )
+		file.bossNextRandomLineTime[ titan ] <- 0.0
+	file.bossNextRandomLineTime[ titan ] = Time() + RandomFloatRange( 20, 30 )
+}
+
+void function MpBossTitan_StopTitanRandomLines( entity titan )
+{
+	titan.Signal( "StopBossTitanRandomLines" )
+}
+
+void function MpBossTitan_CancelBossConversation( entity boss )
+{
+	if ( !( boss in file.mpBossTitanConversation ) ) // this is not a registered boss?
+		return
+
+	// try to stop dialogue that may playing on a player
+	foreach ( entity player, MpBossTitanLineReceiver receiverStruct in file.mpBossTitanLineReceiver )
+	{
+		if ( !IsValid( player ) ) // player disconnted!
+			continue
+
+		entity lastSpeaker = receiverStruct.lastSpeakerTitan
+		string lastSoundAlias = receiverStruct.lastPlayedSoundAlias
+		if ( lastSpeaker == boss && lastSoundAlias != "" )
+			StopSoundOnEntity( player, lastSoundAlias ) // stop last played sound alias
+	}
+
+	boss.Signal( "CancelBossConversation" )
+}
+
+void function MpBossTitan_SetTitanConversationStyle( entity titan, int newStyle )
+{
+	if ( !( titan in file.mpBossTitanConversation ) ) // this is not a registered boss?
+		return
+
+	file.mpBossTitanConversation[titan].conversationStyle = newStyle
+}
+
+void function MpBossTitan_PlayConversationDefault( entity boss, string conv, string bossNameOverride = "", bool forceLine = false )
+{
+	if ( !( boss in file.mpBossTitanConversation ) ) // this is not a registered boss?
+		return
+
+	int conversationStyle = file.mpBossTitanConversation[boss].conversationStyle
+	switch ( conversationStyle )
+	{
+		case eBossTitanConvStyle.DISABLED:
+			break
+
+		case eBossTitanConvStyle.PLAY_TO_TARGET:
+			MpBossTitan_PlayConversationToTarget( boss, conv, bossNameOverride, forceLine )
+			break
+		case eBossTitanConvStyle.PLAY_TO_ALL:
+			MpBossTitan_PlayConversationToAll( boss, conv, bossNameOverride, forceLine )
+			break
+	}
+}
+
+void function MpBossTitan_PlayConversationToTarget( entity boss, string conv, string bossNameOverride = "", bool forceLine = false )
+{
+	if ( !( boss in file.mpBossTitanConversation ) ) // this is not a registered boss?
+		return
+
+	entity player
+	entity enemy = boss.GetEnemy()
+	if ( IsValid( enemy ) )
+	{
+		if ( enemy.IsPlayer() )
+			player = enemy
+		else if ( IsValid( GetPetTitanOwner( enemy ) ) )
+			player = GetPetTitanOwner( enemy )
+	}
+
+	if ( IsValid( player ) )
+		MpBossTitan_TryPlayConversationToPlayer( player, boss, conv, bossNameOverride, forceLine )
+}
+
+void function MpBossTitan_PlayConversationToAll( entity boss, string conv, string bossNameOverride = "", bool forceLine = false )
+{
+	if ( !( boss in file.mpBossTitanConversation ) ) // this is not a registered boss?
+		return
+
+	foreach ( entity player in GetPlayerArray() )
+		MpBossTitan_TryPlayConversationToPlayer( player, boss, conv, bossNameOverride, forceLine )
+}
+
+//  __  __    _    ___ _   _     _   _ _____ ___ _     ___ _______   __
+// |  \/  |  / \  |_ _| \ | |   | | | |_   _|_ _| |   |_ _|_   _\ \ / /
+// | |\/| | / _ \  | ||  \| |   | | | | | |  | || |    | |  | |  \ V / 
+// | |  | |/ ___ \ | || |\  |   | |_| | | |  | || |___ | |  | |   | |  
+// |_|  |_/_/   \_\___|_| \_|    \___/  |_| |___|_____|___| |_|   |_|  
+
+bool function MpBossTitan_TryPlayConversationToPlayer( entity player, entity boss, string conv, string bossNameOverride = "", bool forceLine = false )
+{
+	if ( !( boss in file.mpBossTitanConversation ) ) // this is not a registered boss?
+		return false
+
+	string name = bossNameOverride
+	float timeout = BOSS_TITAN_LINE_TIMEOUT
+	float globalTimeout = timeout
+
+	if ( bossNameOverride == "" ) // empty override name
+	{
+		name = boss.ai.bossCharacterName
+
+		if ( !MpBossTitan_IsGenericTitan( boss ) )
+		{
+			if ( conv == "bossTitan_2segmentsLeft" || conv == "bossTitan_1segmentLeft" ) // hack since bosses only have 2 lines
+				timeout *= 5
+		}
+	}
+
+	// cooldown think
+	if ( conv in file.lastSaidLineTimesOnPlayer[player] )
+	{
+		if ( Time() - file.lastSaidLineTimesOnPlayer[player][conv] < timeout && !forceLine )
+			return false
+	}
+	else
+		file.lastSaidLineTimesOnPlayer[player][conv] <- Time()
+
+	if ( !forceLine && Time() - file.lastSaidLineTimeOnPlayer[player] < globalTimeout * 0.75 )
+		return false
+
+	file.lastSaidLineTimesOnPlayer[player][conv] = Time()
+	file.lastSaidLineTimeOnPlayer[player] = Time()
+
+	#if BOSS_TITAN_LINE_DEBUG_PRINT
+		printt( "===========================================" )
+		printt( "PlayBossTitanLine:" )
+		printt( "conv: " + conv )
+		printt( "name: " + name )
+		string convName = conv + "_" + name.tolower()
+		printt( "convName: " + convName )
+		printt( "target player: " + string( player ) )
+		printt( "===========================================" )
+	#endif
+
+	// find alias from bossName and conv
+	string soundAlias = ""
+	if ( name in file.bossTitanConvData )
+	{
+		if ( conv in file.bossTitanConvData[name] )
+			soundAlias = GetBestAliasForPlayer( file.bossTitanConvData[name][conv], player )
+	}
+	if ( soundAlias == "" ) // can't find sound!
+	{
+		#if BOSS_TITAN_LINE_DEBUG_PRINT
+			print( "Can't find sound alias!" )
+		#endif
+		return false
+	}
+
+	#if BOSS_TITAN_LINE_DEBUG_PRINT
+		print( "Actual sound alias: " + soundAlias )
+	#endif
+
+	// ASH HACK:
+	if ( soundAlias == "diag_sp_BossVdu_BM112_03_01_imc_ash" ) // "Impressive...surprisingly impressive."
+	{
+		// so she doesn't say "Very disappointing. I expected so much more of you." right after saying "Impressive...surprisingly impressive."
+		file.usedAliasesOnPlayer[player].append( "diag_sp_BossVdu_BM112_27_01_imc_ash" )
+	}
+
+	// if player has last speaker valid, stop last sound
+	entity lastSpeaker = file.mpBossTitanLineReceiver[player].lastSpeakerTitan
+	if ( IsValid( lastSpeaker ) )
+	{
+		string lastSoundAlias = file.mpBossTitanLineReceiver[player].lastPlayedSoundAlias
+		if ( lastSoundAlias != "" )
+			StopSoundOnEntity( player, lastSoundAlias ) // stop last played sound alias
+	}
+
+	EmitSoundOnEntityOnlyToPlayer( player, player, soundAlias ) // emit sound on player, so we can stop last sound if needed
+	file.mpBossTitanConversation[boss].lastPlayedSoundAlias = soundAlias // update last played sound alias
+	// update last speaker
+	file.mpBossTitanLineReceiver[player].lastSpeakerTitan = boss
+	file.mpBossTitanLineReceiver[player].lastPlayedSoundAlias = soundAlias
+	// update alias used time
+	if ( !( soundAlias in file.aliasUsedTimesOnPlayer[player] ) )
+		file.aliasUsedTimesOnPlayer[player][soundAlias] <- Time()
+	else
+		file.aliasUsedTimesOnPlayer[player][soundAlias] = Time()
+
+	// if conversation succeeded, we add debounce for next random line
+	DelayNextBossRandomLine( boss )
+	return true
+}
+
+// from sh_ai_boss_titan.gnut
+string function GetBestAliasForPlayer( BossTitanConversation data, entity player )
+{
+	string alias = GetFreshAliasForPlayer( data, player )
+	if ( alias == "" )
+	{
+		float longestTime = 0.0
+		array<string> aliases = clone data.soundAliases
+		aliases.randomize()
+		foreach ( a in aliases )
+		{
+			if (!( a in file.aliasUsedTimesOnPlayer[player] ))
+			{
+				return a
+			}
+			else
+			{
+				float lastUsedDelay = Time() - file.aliasUsedTimesOnPlayer[player][a]
+				if ( lastUsedDelay > longestTime )
+				{
+					longestTime = lastUsedDelay
+					alias = a
+				}
+			}
+		}
+	}
+	else
+	{
+		file.usedAliasesOnPlayer[player].append( alias )
+	}
+
+	return alias
+}
+
+string function GetFreshAliasForPlayer( BossTitanConversation data, entity player )
+{
+	foreach ( alias in data.soundAliases )
+	{
+		#if BOSS_TITAN_LINE_DEBUG_PRINT
+			print( "Current finding alias: " + alias )
+		#endif
+		if ( !file.usedAliasesOnPlayer[player].contains(alias) )
+		{
+			#if BOSS_TITAN_LINE_DEBUG_PRINT
+				print( "Alias " + alias + " is good enough to use!" )
+			#endif
+			return alias
+		}
+	}
+
+	return ""
+}

--- a/unused/modai/_boss_titan_mp(stub).gnut
+++ b/unused/modai/_boss_titan_mp(stub).gnut
@@ -1,0 +1,54 @@
+// From campaign, make it a server-side version
+global function Multiplayer_Boss_Titans_Init
+
+global function MpBossTitan_AddBossTitan
+global function MpBossTitan_RegisterBossTitan
+
+global function MpBossTitan_SetDialogueStyle
+global function MpBossTitan_RunIntroForTitan
+
+global enum eBossTitanDiagStyle
+{
+    PLAY_TO_ALL, // default
+    PLAY_TO_TARGET,
+    DISABLED
+}
+
+struct BossTitanStruct
+{
+    int health // 3* normal titan's health could be nicer
+    int shield
+    float damageReduction // with damage reduction you can avoid making health bar too long, reduce the accuracy of health
+    bool regenShield
+    float coreMultiplier
+    int dialogueStyle = eBossTitanDiagStyle.PLAY_TO_ALL
+
+    void functionref( entity ) introFunc = null // leave intro func empty won't call intro for the boss
+}
+
+void function MP_Boss_Titans_Dialogue_Init
+{
+
+}
+
+void function MpBossTitan_SetDialogueStyle( entity titan, int dialogueStyle )
+{
+
+}
+
+void function Multiplayer_Boss_Titans_Init()
+{
+
+}
+
+void function MpBossTitan_AddBossTitan( entity titan, string bossName )
+{
+
+}
+
+// ____  _____ _____ _   _   _ _   _____   ___ _   _ _____ ____   ___  ____  
+//|  _ \| ____|  ___/ \ | | | | | |_   _| |_ _| \ | |_   _|  _ \ / _ \/ ___| 
+//| | | |  _| | |_ / _ \| | | | |   | |    | ||  \| | | | | |_) | | | \___ \ 
+//| |_| | |___|  _/ ___ \ |_| | |___| |    | || |\  | | | |  _ <| |_| |___) |
+//|____/|_____|_|/_/   \_\___/|_____|_|   |___|_| \_| |_| |_| \_\\___/|____/ 
+


### PR DESCRIPTION
Add npc freeze support with script
Functions:
    - `FreezeNPC()`
    - `UnfreezeNPC()`
    - `NPCIsFrozen()`

Changed Functions
    - Rework function `SetUsedCoreCallback()` to `AddCallback_OnTitanCoreUsed()` and `RemoveCallback_OnTitanCoreUsed()`, so we can add multiple core used callbacks together
    - Remove `IsVDUTitan()` stub function in `_misc_stubs.gnut`

New Functions:
Add boss titan support. A titan spawn with `TITAN_MERCH` will play a intro, spawn with `TITAN_BOSS` will have dialogue support

- Utility Functions 
    - `MpBossTitan_IsGenericTitan()` 
    - `MpBossTitan_TitanIsBoss()`

- Setttings Functions 
    - `MpBossTitan_SetDamageScale()` 
    - `MpBossTitan_SetDamageReductionScale()` 
    - `MpBossTitan_SetTitanConversationStyle()` 
    - `MpBossTitan_SetTitanEnableCoreConversation()`